### PR TITLE
Add AWS Identity Center adapter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67
 	github.com/aws/aws-sdk-go-v2/service/iam v1.41.1
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
+       github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
+       github.com/aws/aws-sdk-go-v2/service/identitystore v1.26.0
+       github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.27.0
 	github.com/aws/smithy-go v1.22.3
 	github.com/bwmarrin/go-objectsid v0.0.0-20191126144531-5fee401a2f37
 	github.com/docker/go-connections v0.5.0

--- a/pkg/aws-identitycenter/adapter.go
+++ b/pkg/aws-identitycenter/adapter.go
@@ -1,0 +1,96 @@
+package awsidentitycenter
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	framework "github.com/sgnl-ai/adapter-framework"
+	api_adapter_v1 "github.com/sgnl-ai/adapter-framework/api/adapter/v1"
+	"github.com/sgnl-ai/adapter-framework/web"
+	"github.com/sgnl-ai/adapters/pkg/config"
+	"github.com/sgnl-ai/adapters/pkg/pagination"
+)
+
+// Adapter implements the framework.Adapter interface to query pages of objects
+// from datasources.
+type Adapter struct {
+	Client Client
+}
+
+// NewAdapter instantiates a new Adapter.
+func NewAdapter(client Client) framework.Adapter[Config] {
+	return &Adapter{Client: client}
+}
+
+// GetPage is called by SGNL's ingestion service to query a page of objects
+// from a datasource.
+func (a *Adapter) GetPage(ctx context.Context, request *framework.Request[Config]) framework.Response {
+	if err := a.ValidateGetPageRequest(ctx, request); err != nil {
+		return framework.NewGetPageResponseError(err)
+	}
+
+	return a.RequestPageFromDatasource(ctx, request)
+}
+
+// RequestPageFromDatasource requests a page of objects from a datasource.
+func (a *Adapter) RequestPageFromDatasource(
+	ctx context.Context, request *framework.Request[Config],
+) framework.Response {
+	var commonConfig *config.CommonConfig
+	if request.Config != nil {
+		commonConfig = request.Config.CommonConfig
+	}
+
+	commonConfig = config.SetMissingCommonConfigDefaults(commonConfig)
+
+	// Unmarshal the current cursor.
+	cursor, err := pagination.UnmarshalCursor[string](request.Cursor)
+	if err != nil {
+		return framework.NewGetPageResponseError(err)
+	}
+
+	awsReq := &Request{
+		Auth: Auth{
+			AccessKey: request.Auth.Basic.Username,
+			SecretKey: request.Auth.Basic.Password,
+			Region:    request.Config.Region,
+		},
+		IdentityStoreID:       request.Config.IdentityStoreID,
+		InstanceARN:           request.Config.InstanceARN,
+		MaxResults:            int32(request.PageSize),
+		EntityExternalID:      request.Entity.ExternalId,
+		Cursor:                cursor,
+		RequestTimeoutSeconds: *commonConfig.RequestTimeoutSeconds,
+	}
+
+	resp, err := a.Client.GetPage(ctx, awsReq)
+	if err != nil {
+		return framework.NewGetPageResponseError(err)
+	}
+
+	if adapterErr := web.HTTPError(resp.StatusCode, resp.RetryAfterHeader); adapterErr != nil {
+		return framework.NewGetPageResponseError(adapterErr)
+	}
+
+	parsedObjects, parserErr := web.ConvertJSONObjectList(
+		&request.Entity,
+		resp.Objects,
+		web.WithLocalTimeZoneOffset(commonConfig.LocalTimeZoneOffset),
+		web.WithDateTimeFormats(
+			[]web.DateTimeFormatWithTimeZone{{Format: time.RFC3339, HasTimeZone: true}}...,
+		),
+	)
+	if parserErr != nil {
+		return framework.NewGetPageResponseError(
+			&framework.Error{Message: fmt.Sprintf("Failed to convert datasource response objects: %v.", parserErr), Code: api_adapter_v1.ErrorCode_ERROR_CODE_INTERNAL},
+		)
+	}
+
+	nextCursor, err := pagination.MarshalCursor(resp.NextCursor)
+	if err != nil {
+		return framework.NewGetPageResponseError(err)
+	}
+
+	return framework.NewGetPageResponseSuccess(&framework.Page{Objects: parsedObjects, NextCursor: nextCursor})
+}

--- a/pkg/aws-identitycenter/client.go
+++ b/pkg/aws-identitycenter/client.go
@@ -1,0 +1,62 @@
+package awsidentitycenter
+
+import (
+	"context"
+
+	framework "github.com/sgnl-ai/adapter-framework"
+	"github.com/sgnl-ai/adapters/pkg/pagination"
+)
+
+// Client is a client that allows querying the datasource which contains JSON objects.
+type Client interface {
+	GetPage(ctx context.Context, request *Request) (*Response, *framework.Error)
+}
+
+type Auth struct {
+	// AccessKey is the access key to authenticate with AWS.
+	AccessKey string
+
+	// SecretKey is the secret key to authenticate with AWS.
+	SecretKey string
+
+	// Region is the AWS region to query.
+	Region string
+}
+
+// Request is a request to the datasource.
+type Request struct {
+	Auth
+
+	// IdentityStoreID is the AWS Identity Store identifier.
+	IdentityStoreID string
+
+	// InstanceARN is the AWS Identity Center instance ARN.
+	InstanceARN string
+
+	// MaxResults is the maximum number of objects to return from the entity.
+	MaxResults int32
+
+	// EntityExternalID is the external ID of the entity.
+	EntityExternalID string
+
+	// Cursor identifies the first object of the page to return.
+	Cursor *pagination.CompositeCursor[string]
+
+	// RequestTimeoutSeconds is the timeout duration for requests made to datasources.
+	RequestTimeoutSeconds int
+}
+
+// Response is a response returned by the datasource.
+type Response struct {
+	// StatusCode is an HTTP status code.
+	StatusCode int
+
+	// RetryAfterHeader is the Retry-After response HTTP header, if set.
+	RetryAfterHeader string
+
+	// Objects is the list of items returned by the datasource.
+	Objects []map[string]any
+
+	// NextCursor is the cursor that identifies the first object of the next page.
+	NextCursor *pagination.CompositeCursor[string]
+}

--- a/pkg/aws-identitycenter/common_test.go
+++ b/pkg/aws-identitycenter/common_test.go
@@ -1,0 +1,21 @@
+package awsidentitycenter_test
+
+import (
+	framework "github.com/sgnl-ai/adapter-framework"
+	adapter "github.com/sgnl-ai/adapters/pkg/aws-identitycenter"
+)
+
+var (
+	validAuthCredentials = &framework.DatasourceAuthCredentials{
+		Basic: &framework.BasicAuthCredentials{
+			Username: "access",
+			Password: "secret",
+		},
+	}
+
+	validConfig = &adapter.Config{
+		Region:          "us-west-2",
+		IdentityStoreID: "d-1234567890",
+		InstanceARN:     "arn:aws:sso:::instance/ssoins-1234567890",
+	}
+)

--- a/pkg/aws-identitycenter/config.go
+++ b/pkg/aws-identitycenter/config.go
@@ -1,0 +1,46 @@
+package awsidentitycenter
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sgnl-ai/adapters/pkg/config"
+)
+
+// Config is the configuration passed in each GetPage calls to the adapter.
+// AWS Identity Center Adapter configuration example:
+//
+// {
+//   "region": "us-west-2",
+//   "identityStoreID": "d-1234567890",
+//   "instanceARN": "arn:aws:sso:::instance/ssoins-1234567890"
+// }
+
+type Config struct {
+	*config.CommonConfig
+
+	// Region is the AWS region to query.
+	Region string `json:"region"`
+
+	// IdentityStoreID is the AWS Identity Store identifier.
+	IdentityStoreID string `json:"identityStoreID"`
+
+	// InstanceARN is the AWS Identity Center instance ARN.
+	InstanceARN string `json:"instanceARN"`
+}
+
+// ValidateConfig validates that a Config received in a GetPage call is valid.
+func (c *Config) Validate(_ context.Context) error {
+	switch {
+	case c == nil:
+		return errors.New("the request contains an empty configuration")
+	case c.Region == "":
+		return errors.New("the AWS Region is not set in the configuration")
+	case c.IdentityStoreID == "":
+		return errors.New("identityStoreID is not set in the configuration")
+	case c.InstanceARN == "":
+		return errors.New("instanceARN is not set in the configuration")
+	default:
+		return nil
+	}
+}

--- a/pkg/aws-identitycenter/datasource.go
+++ b/pkg/aws-identitycenter/datasource.go
@@ -1,0 +1,213 @@
+package awsidentitycenter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	aws_config "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/identitystore"
+	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
+
+	framework "github.com/sgnl-ai/adapter-framework"
+	api_adapter_v1 "github.com/sgnl-ai/adapter-framework/api/adapter/v1"
+	awsadapter "github.com/sgnl-ai/adapters/pkg/aws"
+	customerror "github.com/sgnl-ai/adapters/pkg/errors"
+	"github.com/sgnl-ai/adapters/pkg/pagination"
+)
+
+const (
+	PermissionSet   string = "PermissionSet"
+	User            string = "User"
+	Group           string = "Group"
+	GroupMembership string = "GroupMembership"
+
+	unhandledStatusCode int = -1
+)
+
+var validEntities = map[string]struct{}{
+	PermissionSet:   {},
+	User:            {},
+	Group:           {},
+	GroupMembership: {},
+}
+
+type Datasource struct {
+	Client    *http.Client
+	AWSConfig *aws.Config
+}
+
+// NewClient returns a Client to query the datasource.
+func NewClient(client *http.Client, awsConfig *aws.Config) (Client, error) {
+	if awsConfig == nil {
+		cfg, err := aws_config.LoadDefaultConfig(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		awsConfig = &cfg
+	}
+
+	return &Datasource{AWSConfig: awsConfig, Client: client}, nil
+}
+
+func (d *Datasource) GetPage(ctx context.Context, request *Request) (*Response, *framework.Error) {
+	if _, ok := validEntities[request.EntityExternalID]; !ok {
+		return nil, &framework.Error{
+			Message: fmt.Sprintf("Unsupported entity type: %s", request.EntityExternalID),
+			Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INVALID_ENTITY_CONFIG,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(request.RequestTimeoutSeconds)*time.Second)
+	defer cancel()
+
+	cfg := d.AWSConfig.Copy()
+	cfg.Credentials = credentials.NewStaticCredentialsProvider(request.AccessKey, request.SecretKey, "")
+	cfg.Region = request.Region
+
+	resp := &Response{}
+	var (
+		objects    []map[string]any
+		nextToken  *string
+		statusCode int
+		err        error
+	)
+
+	switch request.EntityExternalID {
+	case PermissionSet:
+		client := ssoadmin.NewFromConfig(cfg)
+		input := &ssoadmin.ListPermissionSetsInput{
+			InstanceArn: aws.String(request.InstanceARN),
+			MaxResults:  request.MaxResults,
+		}
+		if request.Cursor != nil && request.Cursor.Cursor != nil {
+			input.NextToken = request.Cursor.Cursor
+		}
+
+		out, err2 := client.ListPermissionSets(ctx, input)
+		if err2 != nil {
+			err = err2
+			statusCode = statusCodeFromResponseError(err2)
+			break
+		}
+		objects = make([]map[string]any, len(out.PermissionSets))
+		for i, arn := range out.PermissionSets {
+			objects[i] = map[string]any{"Arn": arn}
+		}
+		nextToken = out.NextToken
+		statusCode = http.StatusOK
+	case User:
+		client := identitystore.NewFromConfig(cfg)
+		input := &identitystore.ListUsersInput{
+			IdentityStoreId: aws.String(request.IdentityStoreID),
+			MaxResults:      request.MaxResults,
+		}
+		if request.Cursor != nil && request.Cursor.Cursor != nil {
+			input.NextToken = request.Cursor.Cursor
+		}
+
+		out, err2 := client.ListUsers(ctx, input)
+		if err2 != nil {
+			err = err2
+			statusCode = statusCodeFromResponseError(err2)
+			break
+		}
+		objects = make([]map[string]any, len(out.Users))
+		for i, u := range out.Users {
+			m, convErr := awsadapter.EntityToObjects(u)
+			if convErr != nil {
+				err = fmt.Errorf("failed to convert entity response to map: %w", convErr)
+				statusCode = http.StatusInternalServerError
+				break
+			}
+			objects[i] = m
+		}
+		nextToken = out.NextToken
+		statusCode = http.StatusOK
+	case Group:
+		client := identitystore.NewFromConfig(cfg)
+		input := &identitystore.ListGroupsInput{
+			IdentityStoreId: aws.String(request.IdentityStoreID),
+			MaxResults:      request.MaxResults,
+		}
+		if request.Cursor != nil && request.Cursor.Cursor != nil {
+			input.NextToken = request.Cursor.Cursor
+		}
+
+		out, err2 := client.ListGroups(ctx, input)
+		if err2 != nil {
+			err = err2
+			statusCode = statusCodeFromResponseError(err2)
+			break
+		}
+		objects = make([]map[string]any, len(out.Groups))
+		for i, g := range out.Groups {
+			m, convErr := awsadapter.EntityToObjects(g)
+			if convErr != nil {
+				err = fmt.Errorf("failed to convert entity response to map: %w", convErr)
+				statusCode = http.StatusInternalServerError
+				break
+			}
+			objects[i] = m
+		}
+		nextToken = out.NextToken
+		statusCode = http.StatusOK
+	case GroupMembership:
+		client := identitystore.NewFromConfig(cfg)
+		input := &identitystore.ListGroupMembershipsInput{
+			IdentityStoreId: aws.String(request.IdentityStoreID),
+			MaxResults:      request.MaxResults,
+		}
+		if request.Cursor != nil && request.Cursor.Cursor != nil {
+			input.NextToken = request.Cursor.Cursor
+		}
+
+		out, err2 := client.ListGroupMemberships(ctx, input)
+		if err2 != nil {
+			err = err2
+			statusCode = statusCodeFromResponseError(err2)
+			break
+		}
+		objects = make([]map[string]any, len(out.GroupMemberships))
+		for i, mship := range out.GroupMemberships {
+			m, convErr := awsadapter.EntityToObjects(mship)
+			if convErr != nil {
+				err = fmt.Errorf("failed to convert entity response to map: %w", convErr)
+				statusCode = http.StatusInternalServerError
+				break
+			}
+			objects[i] = m
+		}
+		nextToken = out.NextToken
+		statusCode = http.StatusOK
+	}
+
+	if err != nil {
+		return nil, customerror.UpdateError(&framework.Error{
+			Message: fmt.Sprintf("Failed to fetch AWS Identity Center entity: %s, error: %v.", request.EntityExternalID, err),
+			Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INTERNAL,
+		}, customerror.WithRequestTimeoutMessage(err, request.RequestTimeoutSeconds))
+	}
+
+	resp.StatusCode = statusCode
+	resp.Objects = objects
+	if nextToken != nil {
+		resp.NextCursor = &pagination.CompositeCursor[string]{Cursor: nextToken}
+	}
+
+	return resp, nil
+}
+
+func statusCodeFromResponseError(err error) int {
+	var httpResponseErr *awshttp.ResponseError
+	if errors.As(err, &httpResponseErr) {
+		return httpResponseErr.HTTPStatusCode()
+	}
+
+	return unhandledStatusCode
+}

--- a/pkg/aws-identitycenter/validation.go
+++ b/pkg/aws-identitycenter/validation.go
@@ -1,0 +1,57 @@
+package awsidentitycenter
+
+import (
+	"context"
+	"fmt"
+
+	framework "github.com/sgnl-ai/adapter-framework"
+	api_adapter_v1 "github.com/sgnl-ai/adapter-framework/api/adapter/v1"
+)
+
+const (
+	// The AWS Identity Center APIs support returning up to 100 items per
+	// request. Reference:
+	// https://docs.aws.amazon.com/singlesignon/latest/IdentityStoreAPIReference/API_ListUsers.html
+	maxPageSize = 100
+)
+
+// ValidateGetPageRequest validates the fields of the GetPage Request.
+func (a *Adapter) ValidateGetPageRequest(ctx context.Context, request *framework.Request[Config]) *framework.Error {
+	if err := request.Config.Validate(ctx); err != nil {
+		return &framework.Error{
+			Message: fmt.Sprintf("AWS Identity Center config is invalid: %v.", err.Error()),
+			Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INVALID_DATASOURCE_CONFIG,
+		}
+	}
+
+	if request.Auth == nil || request.Auth.Basic == nil ||
+		request.Auth.Basic.Username == "" || request.Auth.Basic.Password == "" {
+		return &framework.Error{
+			Message: "Provided datasource auth is missing required AWS authorization credentials.",
+			Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INVALID_DATASOURCE_CONFIG,
+		}
+	}
+
+	if _, ok := validEntities[request.Entity.ExternalId]; !ok {
+		return &framework.Error{
+			Message: "Provided entity external ID is invalid.",
+			Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INVALID_ENTITY_CONFIG,
+		}
+	}
+
+	if request.Ordered {
+		return &framework.Error{
+			Message: "Ordered must be set to false.",
+			Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INVALID_ENTITY_CONFIG,
+		}
+	}
+
+	if request.PageSize > maxPageSize {
+		return &framework.Error{
+			Message: fmt.Sprintf("Provided page size (%d) exceeds the maximum allowed (%d).", request.PageSize, maxPageSize),
+			Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INVALID_PAGE_REQUEST_CONFIG,
+		}
+	}
+
+	return nil
+}

--- a/pkg/aws-identitycenter/validation_test.go
+++ b/pkg/aws-identitycenter/validation_test.go
@@ -1,0 +1,56 @@
+package awsidentitycenter_test
+
+import (
+	"testing"
+
+	framework "github.com/sgnl-ai/adapter-framework"
+	api_adapter_v1 "github.com/sgnl-ai/adapter-framework/api/adapter/v1"
+	adapter "github.com/sgnl-ai/adapters/pkg/aws-identitycenter"
+)
+
+func TestValidateGetPageRequest(t *testing.T) {
+	tests := map[string]struct {
+		request *framework.Request[adapter.Config]
+		wantErr *framework.Error
+	}{
+		"valid_request": {
+			request: &framework.Request[adapter.Config]{
+				Auth: validAuthCredentials,
+				Entity: framework.EntityConfig{
+					ExternalId: adapter.User,
+					Attributes: []*framework.AttributeConfig{
+						{ExternalId: "UserId", Type: framework.AttributeTypeString, UniqueId: true},
+					},
+				},
+				Config:   validConfig,
+				PageSize: 10,
+			},
+			wantErr: nil,
+		},
+		"invalid_missing_auth": {
+			request: &framework.Request[adapter.Config]{
+				Entity:   framework.EntityConfig{ExternalId: adapter.User},
+				Config:   validConfig,
+				PageSize: 10,
+			},
+			wantErr: &framework.Error{
+				Message: "Provided datasource auth is missing required AWS authorization credentials.",
+				Code:    api_adapter_v1.ErrorCode_ERROR_CODE_INVALID_DATASOURCE_CONFIG,
+			},
+		},
+	}
+
+	a := &adapter.Adapter{}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotErr := a.ValidateGetPageRequest(nil, tt.request)
+			if (gotErr == nil) != (tt.wantErr == nil) {
+				t.Fatalf("gotErr: %v, wantErr: %v", gotErr, tt.wantErr)
+			}
+			if gotErr != nil && gotErr.Message != tt.wantErr.Message {
+				t.Errorf("gotErr: %v, wantErr: %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement new AWS Identity Center adapter using IdentityStore and SSO admin APIs
- wire up validation and client types
- add basic tests and update go.mod
- fix page size constant (100)

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.2)*
