### PR TITLE
Fix max page size logic to respect ingestion scheduler limit

### DIFF
--- a/pkg/aws-s3/csv.go
+++ b/pkg/aws-s3/csv.go
@@ -182,13 +182,13 @@ func StreamingCSVToPage(
 	hasNext = true
 
 	for int64(len(objects)) < pageSize {
-		if totalBytesRead >= maxProcessingBytesTotal {
-			break
-		}
-
 		rowBytes, bytesRead, rowReadErr := readCSVLine(streamReader)
 
 		if bytesRead > 0 {
+			if (totalBytesRead + bytesRead) > maxProcessingBytesTotal {
+				break
+			}
+
 			totalBytesRead += bytesRead
 		}
 

--- a/pkg/aws-s3/csv_test.go
+++ b/pkg/aws-s3/csv_test.go
@@ -324,7 +324,6 @@ Bob,35,SF,"[{""alias"":""Bobby""}]"`
 			maxProcessingBytesTotal: 8,
 			expectedObjects: []map[string]any{
 				{"colA": "r1", "colB": "1"},
-				{"colA": "r2", "colB": "22"},
 			},
 			expectedHasNext: true,
 		},
@@ -340,17 +339,6 @@ Bob,35,SF,"[{""alias"":""Bobby""}]"`
 				{"colA": "r3", "colB": "333"},
 			},
 			expectedHasNext: false,
-		},
-		"success_max_processing_bytes_total_less_than_first_row_but_first_row_read": {
-			csvData:                 csvDataForProcessingLimit,
-			headers:                 headersForProcessingLimit,
-			pageSize:                3,
-			attrConfig:              attrConfigForProcessingLimit,
-			maxProcessingBytesTotal: 3,
-			expectedObjects: []map[string]any{
-				{"colA": "r1", "colB": "1"},
-			},
-			expectedHasNext: true,
 		},
 		"error_on_record_parse_after_first_row": {
 			csvData:  "good,data\n\"bad,data",


### PR DESCRIPTION
**Description of changes**

If I have a ~1GB file where each row is slightly smaller than 1MB in size (to avoid breaking the `rowSize` limit), in the old logic, if the `INGESTION_SCHEDULER_MAX_CALL_RECV_MSG_SIZE_MB`(50MB) is exceeded, 1 row after that is still being processed (51 rows being returned instead of 50). So the gRPC request returns a response that is greater than the `INGESTION_SCHEDULER_MAX_CALL_RECV_MSG_SIZE_MB` and the ingestion fails. This PR fixes that by not processing the extra row.

**API References**

<!--- Please provide links to the documentation where a reviewer can verify all API calls being made. -->

**Pull request intention**

<!--- Please provide the intent of the PR and delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvement (improve test coverage or code readability)

**Pull request checklist**

<!--- Please DO NOT DELETE this checklist; only add more if applicable. -->

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation (if applicable)
- [ ] I have registered the new adapter (if applicable)
- [ ] I have added a smoke test for the new adapter (if applicable)
- [ ] Any secrets are redacted from smoke test fixtures and no PII is present (if applicable)
