### PR TITLE
Fix flaky SCIM and JIRA Datacenter adapter tests for connection failures

### DIFF
--- a/pkg/jira-datacenter/adapter_test.go
+++ b/pkg/jira-datacenter/adapter_test.go
@@ -329,13 +329,13 @@ func TestAdapterGetPage(t *testing.T) {
 				},
 			},
 		},
-		// This test case uses a random URL instead of the test server's URL, so we should expect an invalid cert.
+		// This test case uses a non-existent local address to ensure connection failure.
 		// This test case also verifies that the "https://" prefix is added to the address if it's not present
 		// which is evident by the error message.
-		"failed_to_make_get_page_request_invalid_certs": {
+		"failed_to_make_get_page_request_connection_refused": {
 			ctx: context.Background(),
 			request: &framework.Request[jiradatacenter_adapter.Config]{
-				Address: "example.com",
+				Address: "localhost:1",
 				Auth: &framework.DatasourceAuthCredentials{
 					Basic: &framework.BasicAuthCredentials{
 						Username: mockUsername,
@@ -356,9 +356,8 @@ func TestAdapterGetPage(t *testing.T) {
 			},
 			wantResponse: framework.Response{
 				Error: &framework.Error{
-					Message: `Failed to execute Jira request: Get "https://example.com/rest/api/latest/groups/picker": ` +
-						`tls: failed to verify certificate: ` +
-						`x509: certificate signed by unknown authority.`,
+					Message: `Failed to execute Jira request: Get "https://localhost:1/rest/api/latest/groups/picker": ` +
+						`dial tcp [::1]:1: connect: connection refused.`,
 					Code: api_adapter_v1.ErrorCode_ERROR_CODE_INTERNAL,
 				},
 			},

--- a/pkg/scim/adapter_test.go
+++ b/pkg/scim/adapter_test.go
@@ -299,13 +299,13 @@ func TestAdapterGetPage(t *testing.T) {
 				},
 			},
 		},
-		// This test case uses a random URL instead of the test server's URL, so we should expect an invalid cert.
+		// This test case uses a non-existent local address to ensure connection failure.
 		// This test case also verifies that the "https://" prefix is added to the address if it's not present
 		// which is evident by the error message.
-		"failed_to_make_get_page_request_invalid_certs": {
+		"failed_to_make_get_page_request_connection_refused": {
 			ctx: context.Background(),
 			request: &framework.Request[scim.Config]{
-				Address: "example.com",
+				Address: "localhost:1",
 				Auth: &framework.DatasourceAuthCredentials{
 					Basic: &framework.BasicAuthCredentials{
 						Username: testUsername,
@@ -328,8 +328,7 @@ func TestAdapterGetPage(t *testing.T) {
 			wantResponse: framework.Response{
 				Error: &framework.Error{
 					Message: `Failed to execute SCIM request: ` +
-						`Get "https://example.com/Users?startIndex=1&count=1": tls: failed to verify certificate: x509: ` +
-						`certificate signed by unknown authority.`,
+						`Get "https://localhost:1/Users?startIndex=1&count=1": dial tcp [::1]:1: connect: connection refused.`,
 					Code: api_adapter_v1.ErrorCode_ERROR_CODE_INTERNAL,
 				},
 			},


### PR DESCRIPTION
**Description of changes**

Changed the test from connecting to example.com (which could timeout or fail with TLS error depending on environment) to localhost:1 (which consistently fails with connection refused). This ensures predictable test behavior across all CI environments.

**API References**

<!--- Please provide links to the documentation where a reviewer can verify all API calls being made. -->

**Pull request intention**

<!--- Please provide the intent of the PR and delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvement (improve test coverage or code readability)

**Pull request checklist**

<!--- Please DO NOT DELETE this checklist; only add more if applicable. -->

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated documentation (if applicable)
- [ ] I have registered the new adapter (if applicable)
- [ ] I have added a smoke test for the new adapter (if applicable)
- [ ] Any secrets are redacted from smoke test fixtures and no PII is present (if applicable)
