### PR TITLE
fix: prevent page size overflow in AzureAD member accumulation

### DIFF
--- a/pkg/azuread/common_test.go
+++ b/pkg/azuread/common_test.go
@@ -593,6 +593,21 @@ var TestServerHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Req
 			]
 		}`))
 
+	// Group Members - 02bd9fd6-8f93-4758-87c3-1fb73740a315 - Members Page 1 with 3 top value:
+	case "/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315/members?$select=id&$top=3":
+		w.Write([]byte(`{
+			"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users",
+			"@odata.nextLink": "https://graph.microsoft.com/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315/members?$select=id&$top=2&$skiptoken=RFNwdAIAAQAAACM6QWRlbGVWQE0zNjV4MjE0MzU1Lm9ubWljcm9zb2Z0LmNvbSlVc2VyXzg3ZDM0OWVkLTQ0ZDctNDNlMS05YTgzLTVmMjQwNmRlZTViZLkAAAAAAAAAAAAA",
+			"value": [
+				{
+					"id": "6e7b768e-07e2-4810-8459-485f84f8f204"
+				},
+				{
+					"id": "87d349ed-44d7-43e1-9a83-5f2406dee5bd"
+				}
+			]
+		}`))
+
 	// Group Members - 02bd9fd6-8f93-4758-87c3-1fb73740a315 - Members Page 2:
 	case "/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315/members?$select=id&$top=2&$skiptoken=RFNwdAIAAQAAACM6QWRlbGVWQE0zNjV4MjE0MzU1Lm9ubWljcm9zb2Z0LmNvbSlVc2VyXzg3ZDM0OWVkLTQ0ZDctNDNlMS05YTgzLTVmMjQwNmRlZTViZLkAAAAAAAAAAAAA":
 		w.Write([]byte(`{

--- a/pkg/azuread/datasource.go
+++ b/pkg/azuread/datasource.go
@@ -94,6 +94,31 @@ func NewClient(client *http.Client) Client {
 	}
 }
 
+// deepCopyCursor creates a deep copy of a CompositeCursor
+func deepCopyCursor(cursor *pagination.CompositeCursor[string]) *pagination.CompositeCursor[string] {
+	if cursor == nil {
+		return nil
+	}
+
+	result := &pagination.CompositeCursor[string]{}
+	if cursor.Cursor != nil {
+		cursorVal := *cursor.Cursor
+		result.Cursor = &cursorVal
+	}
+
+	if cursor.CollectionID != nil {
+		collectionIDVal := *cursor.CollectionID
+		result.CollectionID = &collectionIDVal
+	}
+
+	if cursor.CollectionCursor != nil {
+		collectionCursorVal := *cursor.CollectionCursor
+		result.CollectionCursor = &collectionCursorVal
+	}
+
+	return result
+}
+
 // GetPage fetches a page of data, accumulating members from multiple parent groups if needed to satisfy page size.
 func (d *Datasource) GetPage(ctx context.Context, request *Request) (*Response, *framework.Error) {
 	// Check if this is a member entity that needs accumulation
@@ -108,6 +133,8 @@ func (d *Datasource) GetPage(ctx context.Context, request *Request) (*Response, 
 	accumulatedObjects := make([]map[string]any, 0)
 	currentRequest := *request
 
+	var nextCursor *pagination.CompositeCursor[string]
+
 	for int64(len(accumulatedObjects)) < request.PageSize {
 		response, err := d.getPageBase(ctx, &currentRequest)
 		if err != nil {
@@ -119,17 +146,26 @@ func (d *Datasource) GetPage(ctx context.Context, request *Request) (*Response, 
 		}
 
 		if len(response.Objects) > 0 {
+			if int64(len(response.Objects)+len(accumulatedObjects)) > request.PageSize {
+				// Received more data than asked for. This can happen if Cursor.Cursor
+				// was used to fetch the data with a higher, older page size.
+				break
+			}
+
 			accumulatedObjects = append(accumulatedObjects, response.Objects...)
 		}
 
 		// Check if we have more data to fetch
 		if response.NextCursor == nil {
-			currentRequest.Cursor = nil
+			nextCursor = nil
 
 			break // No more data available
 		}
 
-		// Update the cursor and pagesize for the next iteration
+		// Save the cursor
+		nextCursor = deepCopyCursor(response.NextCursor)
+
+		// Update the cursor
 		currentRequest.Cursor = response.NextCursor
 		currentRequest.PageSize = request.PageSize - int64(len(accumulatedObjects))
 	}
@@ -138,7 +174,7 @@ func (d *Datasource) GetPage(ctx context.Context, request *Request) (*Response, 
 	return &Response{
 		StatusCode: http.StatusOK,
 		Objects:    accumulatedObjects,
-		NextCursor: currentRequest.Cursor,
+		NextCursor: nextCursor,
 	}, nil
 }
 

--- a/pkg/azuread/datasource.go
+++ b/pkg/azuread/datasource.go
@@ -94,13 +94,14 @@ func NewClient(client *http.Client) Client {
 	}
 }
 
-// deepCopyCursor creates a deep copy of a CompositeCursor
+// deepCopyCursor creates a deep copy of a CompositeCursor.
 func deepCopyCursor(cursor *pagination.CompositeCursor[string]) *pagination.CompositeCursor[string] {
 	if cursor == nil {
 		return nil
 	}
 
 	result := &pagination.CompositeCursor[string]{}
+
 	if cursor.Cursor != nil {
 		cursorVal := *cursor.Cursor
 		result.Cursor = &cursorVal

--- a/pkg/azuread/datasource_test.go
+++ b/pkg/azuread/datasource_test.go
@@ -1027,6 +1027,40 @@ func TestGetGroupMembersPage(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		"group_members_pagesize_overflow_prevention": {
+			context: context.Background(),
+			request: &azuread.Request{
+				Token:                 "Bearer Testtoken",
+				BaseURL:               server.URL,
+				EntityExternalID:      "GroupMember",
+				PageSize:              3,
+				APIVersion:            "v1.0",
+				RequestTimeoutSeconds: 5,
+			},
+			wantRes: &azuread.Response{
+				StatusCode: http.StatusOK,
+				Objects: []map[string]any{
+					{
+						"id":       "6e7b768e-07e2-4810-8459-485f84f8f204-02bd9fd6-8f93-4758-87c3-1fb73740a315",
+						"memberId": "6e7b768e-07e2-4810-8459-485f84f8f204",
+						"groupId":  "02bd9fd6-8f93-4758-87c3-1fb73740a315",
+					},
+					{
+						"id":       "87d349ed-44d7-43e1-9a83-5f2406dee5bd-02bd9fd6-8f93-4758-87c3-1fb73740a315",
+						"memberId": "87d349ed-44d7-43e1-9a83-5f2406dee5bd",
+						"groupId":  "02bd9fd6-8f93-4758-87c3-1fb73740a315",
+					},
+				},
+				NextCursor: &pagination.CompositeCursor[string]{
+					// We're of syncing Members for a specific Groups, so this cursor is to the next page of Members.
+					Cursor:       testutil.GenPtr(server.URL + "/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315/members?$select=id&$top=2&$skiptoken=RFNwdAIAAQAAACM6QWRlbGVWQE0zNjV4MjE0MzU1Lm9ubWljcm9zb2Z0LmNvbSlVc2VyXzg3ZDM0OWVkLTQ0ZDctNDNlMS05YTgzLTVmMjQwNmRlZTViZLkAAAAAAAAAAAAA"),
+					CollectionID: testutil.GenPtr("02bd9fd6-8f93-4758-87c3-1fb73740a315"),
+					// GroupCursor to the next page of Groups.
+					CollectionCursor: testutil.GenPtr(server.URL + "/v1.0/groups?$select=id&$top=1&$skiptoken=RFNwdAIAAQAAACpHcm91cF8wNmY2MmY3MC05ODI3LTRlNmUtOTNlZi04ZTBmMmQ5YjdiMjMqR3JvdXBfMDZmNjJmNzAtOTgyNy00ZTZlLTkzZWYtOGUwZjJkOWI3YjIzAAAAAAAAAAAAAAA"),
+				},
+			},
+			wantErr: nil,
+		},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
## Summary
Fixes page size overflow in AzureAD GetPage wrapper that caused SGNL ingestion failures when accumulated objects exceeded the requested page size.

## Problem
The GetPage function for GroupMember entities accumulates members from multiple API calls until reaching the requested page size. However, it didn't check if adding the next batch of objects would exceed the page size limit.

Example: With 980 objects accumulated and API returning 28 more, it would add all 28, resulting in 1,008 objects—exceeding the 999 limit and causing SGNL ingestion to fail with error "returned 1008 objects; page size of 999".

## Solution
Added a check before appending objects: if adding the next batch would exceed `request.PageSize`, break immediately instead of accumulating. This ensures the returned object count never exceeds the requested page size.

## Changes
- Added overflow check before appending objects to prevent exceeding page size limit
- Added `deepCopyCursor` helper function for proper cursor handling
- Preserves cursor to resume from the unfetched page in next sync
- Added unit test `group_members_pagesize_overflow_prevention` to verify overflow prevention

## Test Plan
- [x] Unit tests pass
- [x] Added test case for page size overflow prevention
- [ ] Manual testing with large AzureAD datasets

🤖 Generated with [Claude Code](https://claude.com/claude-code)