### PR TITLE
Pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,7 +80,7 @@ jobs:
 
       # CodeCov
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: "v2.12.2"
           args: --timeout 5m --verbose


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs for supply chain security.

## Changes

| Action | Version | SHA |
|--------|---------|-----|
| dependabot/fetch-metadata | v3 | `25dd0e34f4fe68f24cc83900b1fe3fe149efef98` |
| codecov/codecov-action | v6 | `fb8b3582c8e4def4969c97caa2f19720cb33a72f` |
| golangci/golangci-lint-action | v9 | `82606bf257cbaff209d206a39f5134f0cfbfd2ee` |

## Context

- Jira: [PRODSEC-132424](https://jira.cs.sys/browse/PRODSEC-132424)
- Actions are pinned to the exact commit matching the version tag
- Version preserved as inline comment for readability: `action@<sha> # <version>`

## Test plan

- [ ] Verify workflow syntax is valid (Actions tab shows no parse errors)
- [ ] Confirm pinned SHAs match expected versions

LLM Agent(s) contributed to this PR.
