### PR TITLE
Update DB2 adapter debian image to r1

### DIFF
--- a/Dockerfile.db2
+++ b/Dockerfile.db2
@@ -4,7 +4,7 @@
 # upstream debian:trixie-slim.
 
 ARG GOLANG_IMAGE=golang:1.26-trixie
-ARG RUNTIME_IMAGE=ghcr.io/sgnl-ai/debian:trixie-debian13-fips-r0
+ARG RUNTIME_IMAGE=ghcr.io/sgnl-ai/debian:trixie-debian13-fips-r1
 ARG DB2_CLI_VERSION=v12.1.2
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Description of changes**

Update to `ghcr.io/sgnl-ai/debian:trixie-debian13-fips-r1` to upgrade `openssl` and fix `CVE-2026-34182`.

**API References**

<!--- Please provide links to the documentation where a reviewer can verify all API calls being made. -->

**Pull request intention**

<!--- Please provide the intent of the PR and delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Code improvement (improve test coverage or code readability)

**Pull request checklist**

<!--- Please DO NOT DELETE this checklist; only add more if applicable. -->

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation (if applicable)
- [ ] I have registered the new adapter (if applicable)
- [ ] I have added a smoke test for the new adapter (if applicable)
- [ ] Any secrets are redacted from smoke test fixtures and no PII is present (if applicable)
