### PR TITLE
Contid 10998 stop mass delete ad group members

### DIFF
--- a/pkg/ldap/v1.0.0/datasource.go
+++ b/pkg/ldap/v1.0.0/datasource.go
@@ -554,6 +554,16 @@ func (d *Datasource) GetPage(ctx context.Context, request *Request) (*Response, 
 		}
 
 		if isEmptyLastPage {
+			if memberOfReq.Cursor == nil {
+				return nil, &framework.Error{
+					Message: fmt.Sprintf(
+						"Failed to retrieve parent entities for %s: datasource returned no results for entity %s.",
+						request.EntityExternalID, *memberOf,
+					),
+					Code: api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED,
+				}
+			}
+
 			return &Response{
 				StatusCode: http.StatusOK,
 			}, nil

--- a/pkg/ldap/v1.0.0/datasource_test.go
+++ b/pkg/ldap/v1.0.0/datasource_test.go
@@ -493,6 +493,67 @@ func TestGetTLSConfig(t *testing.T) {
 	}
 }
 
+func TestGetPageReturnsErrorWhenParentEntityReturnsNoResultsForMemberOfEntity(t *testing.T) {
+	memberOf := "Group"
+	collectionAttr := "distinguishedName"
+	memberUniqueID := "dn"
+	memberOfUniqueID := "dn"
+
+	ds := ldap.Datasource{
+		Client: &testProxyClient{
+			proxiedRequest: false,
+		},
+	}
+
+	request := &ldap.Request{
+		BaseURL:          mockLDAPAddr,
+		PageSize:         10,
+		EntityExternalID: "GroupMember",
+		Attributes: []*framework.AttributeConfig{
+			{
+				ExternalId: "id",
+				Type:       framework.AttributeTypeString,
+				UniqueId:   true,
+			},
+		},
+		ConnectionParams: ldap.ConnectionParams{
+			BindDN:       "cn=user,dc=example,dc=org",
+			BindPassword: "password",
+			BaseDN:       "dc=example,dc=org",
+		},
+		UniqueIDAttribute: "id",
+		EntityConfigMap: map[string]*ldap.EntityConfig{
+			"Group": {
+				Query: "(objectClass=group)",
+			},
+			"GroupMember": {
+				MemberOf:                  &memberOf,
+				CollectionAttribute:       &collectionAttr,
+				Query:                     "(&(memberOf={{CollectionId}}))",
+				MemberUniqueIDAttribute:   &memberUniqueID,
+				MemberOfUniqueIDAttribute: &memberOfUniqueID,
+			},
+		},
+		RequestTimeoutSeconds: 30,
+	}
+
+	ctxWithLogger, _ := testutil.NewContextWithObservableLogger(t.Context())
+	resp, ferr := ds.GetPage(ctxWithLogger, request)
+
+	if resp != nil {
+		t.Errorf("expected nil response, got %v", resp)
+	}
+
+	if ferr == nil {
+		t.Fatal("expected error when parent entity returns no results, got nil")
+	}
+
+	if ferr.Code != api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED {
+		t.Errorf("expected error code %v, got %v",
+			api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED, ferr.Code)
+	}
+}
+
 func TestStringAttrValuesToRequestedType_EmptyValuesHandling(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/ldap/v1.0.0/datasource_test.go
+++ b/pkg/ldap/v1.0.0/datasource_test.go
@@ -552,6 +552,165 @@ func TestGetPageReturnsErrorWhenParentEntityReturnsNoResultsForMemberOfEntity(t 
 		t.Errorf("expected error code %v, got %v",
 			api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED, ferr.Code)
 	}
+
+	expectedMsg := "Failed to retrieve parent entities for GroupMember: datasource returned no results for entity Group."
+	if ferr.Message != expectedMsg {
+		t.Errorf("expected error message %q, got %q", expectedMsg, ferr.Message)
+	}
+}
+
+func TestGetPageReturnsSuccessWhenParentEntityReturnsNoResultsDuringMidPagination(t *testing.T) {
+	memberOf := "Group"
+	collectionAttr := "distinguishedName"
+	memberUniqueID := "dn"
+	memberOfUniqueID := "dn"
+
+	ds := ldap.Datasource{
+		Client: &testProxyClient{
+			proxiedRequest: false,
+		},
+	}
+
+	// Simulates mid-pagination: CollectionCursor is set (we've already processed some groups),
+	// Cursor is nil (not mid-member-sync, so UpdateNextCursorFromCollectionAPI runs).
+	collectionCursor := "eyJjdXJzb3IiOiJ0ZXN0In0="
+	request := &ldap.Request{
+		BaseURL:          mockLDAPAddr,
+		PageSize:         10,
+		EntityExternalID: "GroupMember",
+		Attributes: []*framework.AttributeConfig{
+			{
+				ExternalId: "id",
+				Type:       framework.AttributeTypeString,
+				UniqueId:   true,
+			},
+		},
+		ConnectionParams: ldap.ConnectionParams{
+			BindDN:       "cn=user,dc=example,dc=org",
+			BindPassword: "password",
+			BaseDN:       "dc=example,dc=org",
+		},
+		UniqueIDAttribute: "id",
+		EntityConfigMap: map[string]*ldap.EntityConfig{
+			"Group": {
+				Query: "(objectClass=group)",
+			},
+			"GroupMember": {
+				MemberOf:                  &memberOf,
+				CollectionAttribute:       &collectionAttr,
+				Query:                     "(&(memberOf={{CollectionId}}))",
+				MemberUniqueIDAttribute:   &memberUniqueID,
+				MemberOfUniqueIDAttribute: &memberOfUniqueID,
+			},
+		},
+		Cursor: &pagination.CompositeCursor[string]{
+			CollectionCursor: &collectionCursor,
+		},
+		RequestTimeoutSeconds: 30,
+	}
+
+	ctxWithLogger, _ := testutil.NewContextWithObservableLogger(t.Context())
+	resp, ferr := ds.GetPage(ctxWithLogger, request)
+
+	if ferr != nil {
+		t.Fatalf("expected no error during legitimate end-of-sync, got: %v", ferr)
+	}
+
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+}
+
+// memberOfMockClient differentiates responses by entity type: returns groups
+// for the parent entity query but no member attribute for individual group queries.
+type memberOfMockClient struct{}
+
+func (c *memberOfMockClient) Request(_ context.Context, req *ldap.Request) (*ldap.Response, *framework.Error) {
+	if req.EntityExternalID == "Group" {
+		return &ldap.Response{
+			StatusCode: http.StatusOK,
+			Objects: []map[string]any{
+				{
+					"dn":                "cn=EmptyGroup,ou=Groups,dc=example,dc=org",
+					"distinguishedName": "cn=EmptyGroup,ou=Groups,dc=example,dc=org",
+				},
+			},
+		}, nil
+	}
+
+	// For the member query: return empty objects (group has no members matching the filter).
+	return &ldap.Response{
+		StatusCode: http.StatusOK,
+		Objects:    []map[string]any{},
+	}, nil
+}
+
+func (c *memberOfMockClient) ProxyRequest(_ context.Context, _ *connector.ConnectorInfo, _ *ldap.Request) (*ldap.Response, *framework.Error) {
+	return nil, nil
+}
+
+func (c *memberOfMockClient) IsProxied() bool { return false }
+
+func TestGetPageSucceedsWhenGroupHasNoMembers(t *testing.T) {
+	memberOf := "Group"
+	collectionAttr := "distinguishedName"
+	memberUniqueID := "dn"
+	memberOfUniqueID := "dn"
+
+	ds := ldap.Datasource{
+		Client: &memberOfMockClient{},
+	}
+
+	request := &ldap.Request{
+		BaseURL:          mockLDAPAddr,
+		PageSize:         10,
+		EntityExternalID: "GroupMember",
+		Attributes: []*framework.AttributeConfig{
+			{
+				ExternalId: "id",
+				Type:       framework.AttributeTypeString,
+				UniqueId:   true,
+			},
+		},
+		ConnectionParams: ldap.ConnectionParams{
+			BindDN:       "cn=user,dc=example,dc=org",
+			BindPassword: "password",
+			BaseDN:       "dc=example,dc=org",
+		},
+		UniqueIDAttribute: "id",
+		EntityConfigMap: map[string]*ldap.EntityConfig{
+			"Group": {
+				Query: "(objectClass=group)",
+			},
+			"GroupMember": {
+				MemberOf:                  &memberOf,
+				CollectionAttribute:       &collectionAttr,
+				Query:                     "(&(memberOf={{CollectionId}}))",
+				MemberUniqueIDAttribute:   &memberUniqueID,
+				MemberOfUniqueIDAttribute: &memberOfUniqueID,
+			},
+		},
+		RequestTimeoutSeconds: 30,
+	}
+
+	ctxWithLogger, _ := testutil.NewContextWithObservableLogger(t.Context())
+	resp, ferr := ds.GetPage(ctxWithLogger, request)
+
+	if ferr != nil {
+		t.Fatalf("expected no error when group has no members, got: %v", ferr)
+	}
+
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
 }
 
 func TestStringAttrValuesToRequestedType_EmptyValuesHandling(t *testing.T) {

--- a/pkg/ldap/v2.0.0/datasource.go
+++ b/pkg/ldap/v2.0.0/datasource.go
@@ -578,6 +578,16 @@ func (d *Datasource) getMemberOfPage(
 		return nil, err
 	}
 
+	if len(memberOfResp.Objects) == 0 && memberOfResp.NextCursor == nil {
+		return nil, &framework.Error{
+			Message: fmt.Sprintf(
+				"Failed to retrieve parent entities for %s: datasource returned no results for entity %s.",
+				request.EntityExternalID, *entityConfig.MemberOf,
+			),
+			Code: api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED,
+		}
+	}
+
 	// Process groups one by one, making individual range queries for each group
 	var (
 		allGroupMembers      []map[string]any

--- a/pkg/ldap/v2.0.0/datasource.go
+++ b/pkg/ldap/v2.0.0/datasource.go
@@ -578,7 +578,7 @@ func (d *Datasource) getMemberOfPage(
 		return nil, err
 	}
 
-	if len(memberOfResp.Objects) == 0 && memberOfResp.NextCursor == nil {
+	if len(memberOfResp.Objects) == 0 {
 		return nil, &framework.Error{
 			Message: fmt.Sprintf(
 				"Failed to retrieve parent entities for %s: datasource returned no results for entity %s.",

--- a/pkg/ldap/v2.0.0/datasource_test.go
+++ b/pkg/ldap/v2.0.0/datasource_test.go
@@ -493,6 +493,70 @@ func TestGetTLSConfig(t *testing.T) {
 	}
 }
 
+func TestGetMemberOfPageReturnsErrorWhenParentEntityReturnsNoResults(t *testing.T) {
+	memberOf := "Group"
+
+	ds := ldap.Datasource{
+		Client: &testProxyClient{
+			proxiedRequest: false,
+		},
+	}
+
+	request := &ldap.Request{
+		BaseURL:          mockLDAPAddr,
+		PageSize:         10,
+		EntityExternalID: "GroupMember",
+		Attributes: []*framework.AttributeConfig{
+			{
+				ExternalId: "id",
+				Type:       framework.AttributeTypeString,
+				UniqueId:   true,
+			},
+		},
+		ConnectionParams: ldap.ConnectionParams{
+			BindDN:       "cn=user,dc=example,dc=org",
+			BindPassword: "password",
+			BaseDN:       "dc=example,dc=org",
+		},
+		UniqueIDAttribute: "id",
+		EntityConfigMap: map[string]*ldap.EntityConfig{
+			"Group": {
+				Query: "(objectClass=group)",
+			},
+			"GroupMember": {
+				MemberOf:                  &memberOf,
+				CollectionAttribute:       strPtr("distinguishedName"),
+				Query:                     "(&(objectClass=group)({{CollectionAttribute}}={{CollectionId}}))",
+				MemberUniqueIDAttribute:   strPtr("dn"),
+				MemberOfUniqueIDAttribute: strPtr("dn"),
+				MemberAttribute:           strPtr("member"),
+				MemberOfGroupBatchSize:    10,
+			},
+		},
+		RequestTimeoutSeconds: 30,
+	}
+
+	ctxWithLogger, _ := testutil.NewContextWithObservableLogger(t.Context())
+	resp, ferr := ds.GetPage(ctxWithLogger, request)
+
+	if resp != nil {
+		t.Errorf("expected nil response, got %v", resp)
+	}
+
+	if ferr == nil {
+		t.Fatal("expected error when parent entity returns no results, got nil")
+	}
+
+	if ferr.Code != api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED {
+		t.Errorf("expected error code %v, got %v",
+			api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED, ferr.Code)
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
 func TestStringAttrValuesToRequestedType_EmptyValuesHandling(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/ldap/v2.0.0/datasource_test.go
+++ b/pkg/ldap/v2.0.0/datasource_test.go
@@ -551,10 +551,174 @@ func TestGetMemberOfPageReturnsErrorWhenParentEntityReturnsNoResults(t *testing.
 		t.Errorf("expected error code %v, got %v",
 			api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED, ferr.Code)
 	}
+
+	expectedMsg := "Failed to retrieve parent entities for GroupMember: datasource returned no results for entity Group."
+	if ferr.Message != expectedMsg {
+		t.Errorf("expected error message %q, got %q", expectedMsg, ferr.Message)
+	}
 }
 
 func strPtr(s string) *string {
 	return &s
+}
+
+func TestGetMemberOfPageReturnsErrorWhenParentEntityReturnsNoResultsWithCursorSet(t *testing.T) {
+	memberOf := "Group"
+
+	ds := ldap.Datasource{
+		Client: &testProxyClient{
+			proxiedRequest: false,
+		},
+	}
+
+	// base64({"nextPageCursor":null}) — simulates a subsequent page cursor
+	encodedCursor := base64.StdEncoding.EncodeToString([]byte(`{"nextPageCursor":null}`))
+
+	request := &ldap.Request{
+		BaseURL:          mockLDAPAddr,
+		PageSize:         10,
+		EntityExternalID: "GroupMember",
+		Attributes: []*framework.AttributeConfig{
+			{
+				ExternalId: "id",
+				Type:       framework.AttributeTypeString,
+				UniqueId:   true,
+			},
+		},
+		ConnectionParams: ldap.ConnectionParams{
+			BindDN:       "cn=user,dc=example,dc=org",
+			BindPassword: "password",
+			BaseDN:       "dc=example,dc=org",
+		},
+		UniqueIDAttribute: "id",
+		EntityConfigMap: map[string]*ldap.EntityConfig{
+			"Group": {
+				Query: "(objectClass=group)",
+			},
+			"GroupMember": {
+				MemberOf:                  &memberOf,
+				CollectionAttribute:       strPtr("distinguishedName"),
+				Query:                     "(&(objectClass=group)({{CollectionAttribute}}={{CollectionId}}))",
+				MemberUniqueIDAttribute:   strPtr("dn"),
+				MemberOfUniqueIDAttribute: strPtr("dn"),
+				MemberAttribute:           strPtr("member"),
+				MemberOfGroupBatchSize:    10,
+			},
+		},
+		Cursor: &pagination.CompositeCursor[string]{
+			Cursor: &encodedCursor,
+		},
+		RequestTimeoutSeconds: 30,
+	}
+
+	ctxWithLogger, _ := testutil.NewContextWithObservableLogger(t.Context())
+	resp, ferr := ds.GetPage(ctxWithLogger, request)
+
+	if resp != nil {
+		t.Errorf("expected nil response, got %v", resp)
+	}
+
+	if ferr == nil {
+		t.Fatal("expected error when parent entity returns no results (even with cursor set), got nil")
+	}
+
+	if ferr.Code != api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED {
+		t.Errorf("expected error code %v, got %v",
+			api_adapter_v1.ErrorCode_ERROR_CODE_DATASOURCE_FAILED, ferr.Code)
+	}
+}
+
+// memberOfMockClient differentiates responses by entity type: returns groups
+// for the parent entity query but no member attribute for individual group queries.
+type memberOfMockClient struct{}
+
+func (c *memberOfMockClient) Request(_ context.Context, req *ldap.Request) (*ldap.Response, *framework.Error) {
+	if req.EntityExternalID == "Group" {
+		return &ldap.Response{
+			StatusCode: http.StatusOK,
+			Objects: []map[string]any{
+				{
+					"dn":                "cn=EmptyGroup,ou=Groups,dc=example,dc=org",
+					"distinguishedName": "cn=EmptyGroup,ou=Groups,dc=example,dc=org",
+				},
+			},
+		}, nil
+	}
+
+	// For the member query: return the group object without member attribute.
+	return &ldap.Response{
+		StatusCode: http.StatusOK,
+		Objects: []map[string]any{
+			{"dn": "cn=EmptyGroup,ou=Groups,dc=example,dc=org"},
+		},
+	}, nil
+}
+
+func (c *memberOfMockClient) ProxyRequest(_ context.Context, _ *connector.ConnectorInfo, _ *ldap.Request) (*ldap.Response, *framework.Error) {
+	return nil, nil
+}
+
+func (c *memberOfMockClient) IsProxied() bool { return false }
+
+func TestGetMemberOfPageSucceedsWhenGroupHasNoMembers(t *testing.T) {
+	memberOf := "Group"
+
+	ds := ldap.Datasource{
+		Client: &memberOfMockClient{},
+	}
+
+	request := &ldap.Request{
+		BaseURL:          mockLDAPAddr,
+		PageSize:         10,
+		EntityExternalID: "GroupMember",
+		Attributes: []*framework.AttributeConfig{
+			{
+				ExternalId: "id",
+				Type:       framework.AttributeTypeString,
+				UniqueId:   true,
+			},
+		},
+		ConnectionParams: ldap.ConnectionParams{
+			BindDN:       "cn=user,dc=example,dc=org",
+			BindPassword: "password",
+			BaseDN:       "dc=example,dc=org",
+		},
+		UniqueIDAttribute: "id",
+		EntityConfigMap: map[string]*ldap.EntityConfig{
+			"Group": {
+				Query: "(objectClass=group)",
+			},
+			"GroupMember": {
+				MemberOf:                  &memberOf,
+				CollectionAttribute:       strPtr("distinguishedName"),
+				Query:                     "(&(objectClass=group)({{CollectionAttribute}}={{CollectionId}}))",
+				MemberUniqueIDAttribute:   strPtr("dn"),
+				MemberOfUniqueIDAttribute: strPtr("dn"),
+				MemberAttribute:           strPtr("member"),
+				MemberOfGroupBatchSize:    10,
+			},
+		},
+		RequestTimeoutSeconds: 30,
+	}
+
+	ctxWithLogger, _ := testutil.NewContextWithObservableLogger(t.Context())
+	resp, ferr := ds.GetPage(ctxWithLogger, request)
+
+	if ferr != nil {
+		t.Fatalf("expected no error when group has no members, got: %v", ferr)
+	}
+
+	if resp == nil {
+		t.Fatal("expected non-nil response")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	if len(resp.Objects) != 0 {
+		t.Errorf("expected 0 member objects for group with no members, got %d", len(resp.Objects))
+	}
 }
 
 func TestStringAttrValuesToRequestedType_EmptyValuesHandling(t *testing.T) {


### PR DESCRIPTION
**Description of changes**

When the LDAP adapter can't reach Active Directory (network connectivity issue), User and Group collections fail

correctly. However, the GroupMember collection returns a 200 OK response with empty objects instead of failing. This

causes SGNL to interpret "no members" as the targets state and deletes all existing membership data from SGNL.


**API References**

<!--- Please provide links to the documentation where a reviewer can verify all API calls being made. -->

**Pull request intention**

<!--- Please provide the intent of the PR and delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvement (improve test coverage or code readability)

**Pull request checklist**

<!--- Please DO NOT DELETE this checklist; only add more if applicable. -->

- [ ] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation (if applicable)
- [ ] I have registered the new adapter (if applicable)
- [ ] I have added a smoke test for the new adapter (if applicable)
- [ ] Any secrets are redacted from smoke test fixtures and no PII is present (if applicable)
