### PR TITLE
[chore] Migrate secrets to CI environment in GHA workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   build-and-push:
+    environment: CI
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
**Description of changes**

Add `environment: CI` to GHA workflow jobs that reference `CODECOV_TOKEN` or `SGNL_ROBOT_PAT`. These secrets are now set at the environment level (CI environment) rather than repo level, enabling finer-grained access control per job.

**Jira ticket linked**

N/A

**Pull request intention**

- [x] Code improvement (improve test coverage or code readability)

**Pull request checklist**

- [x] I have performed a self-review of my own code
- [x] I have updated documentation (if applicable)

**Self identified pull request size**

- [x] XS (Extra Small) SLO - 4 hours

**AI usage**

- [x] AI was used in this PR

**AI contribution** (select one if AI was used)

- [x] High (> 75%) — AI generated the majority of this PR

**Estimated AI cost** (select one if AI was used)

- [x] < $5

LLM Agent(s) contributed to this PR.
