### PR TITLE
fix: prevent member data loss for large AD groups (>1500 members)

### DIFF
--- a/pkg/ldap/v2.0.0/datasource.go
+++ b/pkg/ldap/v2.0.0/datasource.go
@@ -844,11 +844,12 @@ func extractMembersDNFromGroup(memberObjs map[string]any, offset, count int) ([]
 			memberList = memberList[offset:]
 		}
 
-		if count > len(memberList) {
-			count = len(memberList)
+		extractCount := count
+		if extractCount > len(memberList) {
+			extractCount = len(memberList)
 		}
 
-		for _, member := range memberList[:count] {
+		for _, member := range memberList[:extractCount] {
 			if memberDN, ok := member.(string); ok {
 				membersDN = append(membersDN, memberDN)
 			} else {
@@ -869,14 +870,14 @@ func extractMembersDNFromGroup(memberObjs map[string]any, offset, count int) ([]
 		// Ref: https://learn.microsoft.com/en-us/windows/win32/adschema/attributes/memberof
 
 		if matches := rangeAttributePattern.FindStringSubmatch(attrName); matches != nil {
-			if matches[3] == "*" && count == len(memberList) {
+			if matches[3] == "*" && extractCount == len(memberList) {
 				return membersDN, MemberExtractionActionDone
 			}
 
 			return membersDN, MemberExtractionActionContinueRange
 		}
 
-		if count == len(memberList) {
+		if extractCount == len(memberList) {
 			return membersDN, MemberExtractionActionDone
 		}
 
@@ -1049,7 +1050,7 @@ func StringAttrValuesToRequestedType(
 ) (any, *framework.Error) {
 	if isList {
 		if len(attr.Values) == 0 { // empty values
-			return attr.Values, nil
+			return []any{}, nil
 		}
 
 		values := make([]any, 0, len(attr.Values))

--- a/pkg/ldap/v2.0.0/extract_members_test.go
+++ b/pkg/ldap/v2.0.0/extract_members_test.go
@@ -245,6 +245,21 @@ func TestExtractMembersDNFromGroup(t *testing.T) {
 			expectedDNS:    []string{},
 			expectedAction: MemberExtractionActionDone,
 		},
+
+		// Proxy round-trip scenario: AD returns both empty "member" and populated range attr.
+		// JSON marshaling converts []string{} to []any{}, so "member" becomes []any{} (not []string{}).
+		// With randomized map iteration, if empty "member" is visited first it must not corrupt count.
+		{
+			name: "empty_member_with_range_attr_proxy_roundtrip",
+			memberObjs: map[string]any{
+				"member":              []any{},
+				"member;range=0-1499": makeMemberList(1500),
+			},
+			offset:         0,
+			count:          99,
+			expectedDNS:    makeExpectedDNS(0, 99),
+			expectedAction: MemberExtractionActionContinueRange,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When AD returns both an empty `member` attr and a populated `member;range=0-1499` attr, randomized map iteration could visit the empty attr first, mutating `count` to 0 and causing the range attr iteration to extract nothing. Use a per-iteration `extractCount` local instead. Also return `[]any{}` from StringAttrValuesToRequestedType for empty lists so type assertions behave consistently after JSON round-trip.

**Description of changes**

<!--- Please provide a description of this PR. -->

**API References**

<!--- Please provide links to the documentation where a reviewer can verify all API calls being made. -->

**Pull request intention**

<!--- Please provide the intent of the PR and delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvement (improve test coverage or code readability)

**Pull request checklist**

<!--- Please DO NOT DELETE this checklist; only add more if applicable. -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated documentation (if applicable)
- [ ] I have registered the new adapter (if applicable)
- [ ] I have added a smoke test for the new adapter (if applicable)
- [ ] Any secrets are redacted from smoke test fixtures and no PII is present (if applicable)
