### PR TITLE
External ID README for each package

### DIFF
--- a/pkg/aws-s3/README.md
+++ b/pkg/aws-s3/README.md
@@ -1,0 +1,48 @@
+# AWS S3 Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a CSV filename in an S3 bucket. The adapter constructs the S3 object key as:
+
+```
+{prefix}/{entityExternalID}.{fileType}
+```
+
+The adapter is open-ended - any filename (without extension) can be used as an entity external ID.
+
+| Entity External ID | S3 Object Key (with prefix `data/internal`) | Description |
+|---|---|---|
+| `users` | `data/internal/users.csv` | Users CSV file |
+| `customers` | `data/internal/customers.csv` | Customers CSV file |
+| `sales` | `data/internal/sales.csv` | Sales CSV file |
+
+## How It Works
+
+The Entity External ID is combined with the configured path prefix and file type to form the S3 object key. The adapter then fetches that object from the configured S3 bucket using the AWS SDK's `GetObject` API.
+
+Example: with config `bucket: "my-bucket"`, `prefix: "exports/2024"`, entity external ID `"orders"`, file type `"csv"`:
+- S3 path: `s3://my-bucket/exports/2024/orders.csv`
+
+## Configuration
+
+```json
+{
+  "region": "us-east-1",
+  "bucket": "my-data-bucket",
+  "prefix": "data/internal",
+  "fileType": "csv"
+}
+```
+
+## Notes
+
+- The only supported file type is `csv`.
+- Max page size is 1000.
+- Attribute external IDs correspond to CSV column headers.
+- Authentication uses AWS access key/secret key credentials.
+
+## Adding New Entity External IDs
+
+**No code changes required.** The adapter uses the entity external ID as the filename (without extension) in the S3 bucket. Simply configure a new entity in SGNL with a name matching the CSV file (e.g., if the file is `departments.csv`, set the entity external ID to `departments`).
+
+Ensure the CSV file exists at `{prefix}/{entityExternalID}.csv` in the configured S3 bucket. Attribute external IDs must match the CSV column headers exactly.

--- a/pkg/aws/README.md
+++ b/pkg/aws/README.md
@@ -1,0 +1,52 @@
+# AWS IAM Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to AWS IAM SDK API calls. Unlike REST-based adapters, this adapter uses the AWS SDK v2 rather than constructing HTTP URLs directly.
+
+| Entity External ID | AWS IAM API Call (List) | AWS IAM API Call (Get) | Description |
+|---|---|---|---|
+| `User` | `ListUsers` | `GetUser` | IAM users |
+| `Group` | `ListGroups` | `GetGroup` | IAM groups |
+| `GroupMember` | `GetGroup` (returns `.Users`) | - | Group members (child of Group) |
+| `Role` | `ListRoles` | `GetRole` | IAM roles |
+| `IdentityProvider` | `ListSAMLProviders` | - | SAML identity providers |
+| `Policy` | `ListPolicies` | `GetPolicy` | IAM policies |
+| `RolePolicy` | `ListAttachedRolePolicies` | - | Policies attached to roles (child of Role) |
+| `UserPolicy` | `ListAttachedUserPolicies` | - | Policies attached to users (child of User) |
+| `GroupPolicy` | `ListAttachedGroupPolicies` | - | Policies attached to groups (child of Group) |
+
+## Parent-Child Relationships
+
+| Child Entity | Parent Entity | Collection Attribute |
+|---|---|---|
+| `GroupMember` | `Group` | `GroupName` |
+| `GroupPolicy` | `Group` | `GroupName` |
+| `RolePolicy` | `Role` | `RoleName` |
+| `UserPolicy` | `User` | `UserName` |
+
+Child entities iterate through their parent collection and fetch associated records per parent.
+
+## Unique ID Construction
+
+- Top-level entities use an `id` field constructed from their ARN.
+- Member/policy entities use a composite ID: `{memberUniqueID}-{parentUniqueID}`.
+
+## Notes
+
+- Supports cross-account access via STS `AssumeRole` with configured role ARNs.
+- Max page size is 1000, max resource accounts is 100.
+- The adapter uses the AWS SDK internally - the underlying endpoint is `https://iam.amazonaws.com/`.
+
+## Adding New Entity External IDs
+
+**Requires code changes.** The adapter validates against `ValidEntityExternalIDs` and uses a switch statement in `datasource.go` to dispatch to entity-specific SDK call handlers.
+
+To add a new entity:
+
+1. Add a constant in `datasource.go` (e.g., `InstanceProfile string = "InstanceProfile"`).
+2. Add an entry to `ValidEntityExternalIDs` with the ARN attribute, unique name field, and parent relationship (if any).
+3. Create a handler struct in `iam.go` implementing the list/get SDK calls (following the pattern of `UserHandler`, `GroupHandler`, etc.).
+4. Add a case in the switch statement in `GetPage` to dispatch to the new handler via `FetchEntities`.
+5. If it's a child entity, set `MemberOf` and `CollectionAttribute` to configure parent iteration.
+6. Add tests.

--- a/pkg/azuread/README.md
+++ b/pkg/azuread/README.md
@@ -1,0 +1,48 @@
+# Azure AD (Entra ID) Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a Microsoft Graph API resource path. The adapter constructs URLs as:
+
+```
+{baseURL}/{apiVersion}/{path}
+```
+
+Where `apiVersion` is `v1.0`.
+
+| Entity External ID | API Path | Description |
+|---|---|---|
+| `User` | `/users` | Azure AD users |
+| `Group` | `/groups` | Azure AD groups |
+| `GroupMember` | `/groups/{groupID}/members` | Members of a specific group (child of Group) |
+| `Application` | `/applications` | Registered applications |
+| `Device` | `/devices` | Registered devices |
+| `Role` | `/directoryRoles` | Directory roles |
+| `RoleMember` | `/users/{userID}/transitiveMemberOf/microsoft.graph.directoryRole` | Roles assigned to a user (child of User) |
+| `RoleAssignment` | `/roleManagement/directory/roleAssignments` | Role assignment records |
+| `RoleAssignmentScheduleRequest` | `/roleManagement/directory/roleAssignmentScheduleRequests` | PIM role assignment schedule requests |
+| `GroupAssignmentScheduleRequest` | `/identityGovernance/privilegedAccess/group/assignmentScheduleRequests` | PIM group assignment schedule requests |
+
+## Parent-Child Relationships
+
+- `GroupMember` is a child of `Group` - the adapter iterates groups and fetches members per group.
+- `RoleMember` is a child of `User` - the adapter iterates users and fetches their transitive role memberships.
+
+## Adding New Entity External IDs
+
+**Requires code changes.** The adapter validates against a fixed `ValidEntityExternalIDs` map and uses a switch statement in `endpoint.go` to construct entity-specific URL paths.
+
+To add a new entity:
+
+1. Add a constant in `datasource.go` (e.g., `ServicePrincipal string = "ServicePrincipal"`).
+2. Add an entry to `ValidEntityExternalIDs` in `datasource.go` specifying whether it has a parent (`memberOf`).
+3. Add a case in `ConstructEndpoint` in `endpoint.go` with the Microsoft Graph API path (e.g., `/servicePrincipals`).
+4. If the entity is a child (member), configure `memberOf` to point to the parent entity and implement collection-based pagination.
+5. If the entity needs `$expand` support, add it to the `expandableRelationships` map.
+6. Add tests in `endpoint_test.go` and `adapter_test.go`.
+
+## Notes
+
+- GroupMember supports type-filtering via advanced filters (e.g., only user members via `/microsoft.graph.user` suffix).
+- Expandable relationships are supported on User, Group, Application, and Device entities (e.g., `$expand=manager`).
+- PIM entities use `$top`/`$skip` pagination instead of `@odata.nextLink` cursors.

--- a/pkg/bamboohr/README.md
+++ b/pkg/bamboohr/README.md
@@ -1,0 +1,38 @@
+# BambooHR Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a BambooHR API path. The adapter constructs URLs as:
+
+```
+{baseURL}/{companyDomain}/{apiVersion}/reports/custom?format=JSON&onlyCurrent={bool}
+```
+
+| Entity External ID | API Path | Description |
+|---|---|---|
+| `Employee` | `/reports/custom` | BambooHR employee records |
+
+## How It Works
+
+This is the only supported entity. The adapter issues a POST request with a JSON body containing the list of attribute external IDs (field names) to retrieve:
+
+```json
+{"fields": ["id", "firstName", "lastName", ...]}
+```
+
+## Required Attribute
+
+Every request must include the attribute with external ID `id` - this is the unique identifier for employee records.
+
+## Adding New Entity External IDs
+
+**Requires code changes.** The adapter only supports `Employee` via the `ValidEntityExternalIDs` map, and the URL construction is hardcoded to the Custom Reports API path.
+
+To add a new entity:
+
+1. Add a constant in `datasource.go` (e.g., `TimeOff = "TimeOff"`).
+2. Add an entry to `ValidEntityExternalIDs` with the corresponding BambooHR API path.
+3. Update `ConstructEndpoint` in `endpoint.go` to handle the new path pattern.
+4. If the new entity uses a different request method or body format, update `GetPage` in `datasource.go`.
+5. Add validation for the new entity's required unique ID attribute in `validation.go`.
+6. Add tests.

--- a/pkg/crowdstrike/README.md
+++ b/pkg/crowdstrike/README.md
@@ -1,0 +1,205 @@
+# CrowdStrike Adapter
+
+## Entity External IDs
+
+The CrowdStrike adapter supports two API mechanisms: GraphQL (Identity Protection) and REST (Endpoint Protection). The Entity External ID determines which mechanism and endpoint is used.
+
+### GraphQL Entities (Identity Protection)
+
+These entities query the CrowdStrike Identity Protection GraphQL API:
+
+```
+{baseURL}/identity-protection/combined/graphql/{apiVersion}
+```
+
+| Entity External ID | Unique ID Attribute | Order By | Description |
+|---|---|---|---|
+| `user` | `entityId` | `RISK_SCORE` | Identity Protection users |
+| `incident` | `incidentId` | `END_TIME` | Identity Protection incidents |
+| `endpoint` | `entityId` | `RISK_SCORE` | Identity Protection endpoints |
+
+### How GraphQL Queries Work
+
+Each entity external ID has a dedicated `QueryBuilder` that generates a specific GraphQL query. The adapter uses the `machinebox/graphql` client to POST queries to the Identity Protection endpoint.
+
+**Query dispatch** (`GetQueryBuilder` in `query.go`):
+- `user` -> `UserQueryBuilder`
+- `incident` -> `IncidentQueryBuilder`
+- `endpoint` -> `EndpointQueryBuilder`
+
+#### User Query
+
+Queries the `entities` field with `types: [USER]`:
+
+```graphql
+{
+  entities(
+    archived: false
+    enabled: true
+    types: [USER]
+    sortKey: RISK_SCORE
+    sortOrder: DESCENDING
+    first: 100
+    after: "cursor..."
+  ) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on UserEntity {
+        entityId
+        primaryDisplayName
+        emailAddresses
+        riskScore
+        riskScoreSeverity
+        mostRecentActivity
+        accounts {
+          ... on ActiveDirectoryAccountDescriptor {
+            domain
+            samAccountName
+            upn
+            enabled
+            ...
+          }
+        }
+        riskFactors {
+          score
+          severity
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+Key fields returned: `entityId`, `primaryDisplayName`, `emailAddresses`, `riskScore`, `riskScoreSeverity`, `impactScore`, `mostRecentActivity`, `inactive`, `stale`, `watched`, `shared`, nested `accounts` (Active Directory details), and `riskFactors`.
+
+#### Incident Query
+
+Queries the `incidents` field:
+
+```graphql
+{
+  incidents(
+    first: 100
+    sortKey: END_TIME
+    sortOrder: DESCENDING
+    after: "cursor..."
+  ) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      incidentId
+      severity
+      type
+      startTime
+      endTime
+      lifeCycleStage
+      compromisedEntities { entityId, primaryDisplayName, riskScore, ... }
+      alertEvents { alertId, alertType, eventSeverity, entities {...}, ... }
+    }
+  }
+}
+```
+
+Key fields returned: `incidentId`, `severity`, `type`, `startTime`, `endTime`, `lifeCycleStage`, nested `compromisedEntities` (entities involved), and `alertEvents` (alerts with their own nested entities).
+
+#### Endpoint Query
+
+Queries the `entities` field with `types: [ENDPOINT]`:
+
+```graphql
+{
+  entities(
+    archived: false
+    enabled: true
+    types: [ENDPOINT]
+    sortKey: RISK_SCORE
+    sortOrder: DESCENDING
+    first: 100
+    after: "cursor..."
+  ) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on EndpointEntity {
+        entityId
+        hostName
+        lastIpAddress
+        riskScore
+        ztaScore
+        agentId
+        accounts {
+          ... on ActiveDirectoryAccountDescriptor { ... }
+        }
+        riskFactors { score, severity, type }
+      }
+    }
+  }
+}
+```
+
+Key fields returned: `entityId`, `hostName`, `lastIpAddress`, `riskScore`, `ztaScore`, `agentId`, `agentVersion`, `cid`, `unmanaged`, `staticIpAddresses`, nested `accounts` and `riskFactors`.
+
+### GraphQL Pagination
+
+All GraphQL entities use cursor-based pagination via the `pageInfo` object:
+- `hasNextPage` - indicates whether more results exist
+- `endCursor` - opaque cursor string passed as the `after` parameter in the next request
+
+The cursor is base64-encoded and stored as a `CompositeCursor` between pages.
+
+### GraphQL Response Parsing
+
+The response is parsed based on the entity external ID:
+- `user` and `endpoint` -> reads from `data.entities.nodes`
+- `incident` -> reads from `data.incidents.nodes`
+
+### Configuration Parameters
+
+GraphQL entities support these config options:
+- `archived` (bool) - include archived entities (applies to `user` and `endpoint`)
+- `enabled` (bool) - filter to enabled entities only (applies to `user` and `endpoint`)
+- `apiVersion` - API version for the endpoint URL path
+
+### REST Entities (Endpoint Protection)
+
+These entities query CrowdStrike REST APIs:
+
+| Entity External ID | List Endpoint | Get Endpoint | Description |
+|---|---|---|---|
+| `endpoint_protection_device` | `GET devices/queries/devices-scroll/v1` | `POST devices/entities/devices/v2` | Falcon endpoint devices |
+| `endpoint_protection_incident` | `GET incidents/queries/incidents/v1` | `POST incidents/entities/incidents/GET/v1` | Falcon incidents |
+| `endpoint_protection_alert` | (combined API) | `POST alerts/combined/alerts/v1` | Falcon alerts |
+
+## How REST Entities Work
+
+- `endpoint_protection_device` and `endpoint_protection_incident` use a two-step pattern: first list resource IDs (GET), then fetch full objects by ID (POST with `{"ids": [...]}`).
+- `endpoint_protection_alert` uses a single combined API with pagination via `after` cursor in the POST body.
+
+## Adding New Entity External IDs
+
+**Requires code changes.** Both GraphQL and REST entities are hardcoded with specific query builders and endpoint mappings.
+
+### Adding a GraphQL entity:
+
+1. Add a constant in `datasource.go` (e.g., `Group string = "group"`).
+2. Add the entity to `ValidGraphQLEntityExternalIDs` in `datasource.go` with its unique ID attribute and order-by field.
+3. Create a new `QueryBuilder` struct and `Build` method in `query.go` that generates the GraphQL query string.
+4. Add a case in `GetQueryBuilder` to dispatch to the new builder.
+5. If the response field differs from `entities`, update `parseGraphQLResponse` in `datasource_graphql.go`.
+6. Add tests.
+
+### Adding a REST entity:
+
+1. Add a constant in `datasource.go`.
+2. Add the entity to `ValidRESTEntityExternalIDs` in `datasource.go` specifying cursor type and whether it uses the list-then-get pattern.
+3. Add an `EndpointInfo` entry in `EntityExternalIDToEndpoint` in `endpoint.go` with the list and/or get endpoint paths.
+4. If the entity needs special request body handling (like alerts), add logic in `datasource_rest.go`.
+5. Add tests.

--- a/pkg/db2/README.md
+++ b/pkg/db2/README.md
@@ -1,0 +1,63 @@
+# DB2 Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a DB2 table name. The adapter constructs SQL queries as:
+
+```sql
+SELECT {columns} FROM [{schema}.]{entityExternalID}
+WHERE {cursor_condition}
+ORDER BY {unique_key_columns}
+FETCH FIRST {pageSize + 1} ROWS ONLY
+```
+
+The adapter is open-ended - any valid DB2 table name can be used as an entity external ID.
+
+| Entity External ID | SQL Table | Description |
+|---|---|---|
+| `ITEMS` | `"ITEMS"` | Items table |
+| `EKPO` | `"EKPO"` | SAP purchase order items |
+| `users` | `"users"` | Users table |
+
+## How It Works
+
+The Entity External ID is quoted and placed directly in the SQL `FROM` clause. If a schema is configured, it becomes `"SCHEMA"."TABLE"`.
+
+Example with entity external ID `ITEMS`, schema `TEST_SCHEMA`:
+```sql
+SELECT "TENANT_ID", "DOC_NUM", "AMOUNT", "REGION"
+FROM "TEST_SCHEMA"."ITEMS"
+WHERE CAST("TENANT_ID" AS VARCHAR(50)) > ?
+ORDER BY CAST("TENANT_ID" AS VARCHAR(50))
+FETCH FIRST 11 ROWS ONLY
+```
+
+## Synthetic Composite ID
+
+When an entity has the attribute external ID `id` marked as the unique ID, the adapter:
+1. Queries DB2 system catalog (`SYSCAT.TABCONST` + `SYSCAT.KEYCOLUSE`) to discover primary key columns.
+2. Adds those PK columns to the SELECT.
+3. Concatenates their values with `|` as separator (e.g., `"T1|D1003|L01"`).
+
+## Connection
+
+The adapter connects via TCP using the DB2 driver:
+```
+HOSTNAME={host};DATABASE={db};UID={user};PWD={pass};PORT={port};PROTOCOL=TCPIP
+```
+
+## Notes
+
+- All entity and attribute external IDs are validated as safe SQL identifiers before use.
+- Pagination uses cursor-based keyset pagination (comparing cast-to-VARCHAR values).
+- Filters are configured per entity external ID in the adapter configuration.
+- Supports optional SSL connections.
+
+## Adding New Entity External IDs
+
+**No code changes required.** The adapter uses any entity external ID directly as the DB2 table name in the `FROM` clause. Simply configure a new entity in SGNL with the DB2 table name (e.g., `EMPLOYEES`, `ORDERS`, `MARA`) and it will work.
+
+Requirements for the entity external ID:
+- Must be a valid SQL identifier (letters, digits, `$`, `_`, max 128 characters).
+- Must correspond to an existing table in the configured database (and schema, if specified).
+- Attribute external IDs must match column names in that table.

--- a/pkg/duo/README.md
+++ b/pkg/duo/README.md
@@ -1,0 +1,32 @@
+# Duo Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a Duo Admin API path segment. The adapter constructs URLs as:
+
+```
+{baseURL}/admin/v1/{path}?limit={pageSize}&offset={offset}
+```
+
+| Entity External ID | API Path | Unique ID Attribute | Description |
+|---|---|---|---|
+| `User` | `users` | `user_id` | Duo users |
+| `Group` | `groups` | `group_id` | Duo groups |
+| `Phone` | `phones` | `phone_id` | Registered phones |
+| `Endpoint` | `endpoints` | `epkey` | Registered endpoints/devices |
+
+## Notes
+
+- The only supported API version is `v1`.
+- Pagination uses offset-based pagination (`limit` + `offset` query params).
+
+## Adding New Entity External IDs
+
+**Requires code changes.** The adapter validates against a fixed `ValidEntityExternalIDs` map that defines the path segment and unique ID attribute for each entity.
+
+To add a new entity:
+
+1. Add a constant in `datasource.go` (e.g., `Token = "Token"`).
+2. Add an entry to `ValidEntityExternalIDs` with the Duo Admin API path (e.g., `tokens`) and unique ID attribute.
+3. Validation will automatically accept the new entity since it checks against this map.
+4. Add tests in `endpoint_test.go` and `adapter_test.go`.

--- a/pkg/github/README.md
+++ b/pkg/github/README.md
@@ -1,0 +1,68 @@
+# GitHub Adapter
+
+## Entity External IDs
+
+The GitHub adapter primarily uses GraphQL to query GitHub Enterprise data, with one REST-based entity. The Entity External ID determines which GraphQL query or REST endpoint is used.
+
+### GraphQL Entities
+
+All GraphQL entities query:
+- **Enterprise Cloud:** `{baseURL}/graphql`
+- **Enterprise Server:** `{baseURL}/api/graphql`
+
+| Entity External ID | Unique ID Attribute | Description |
+|---|---|---|
+| `Organization` | `id` | Enterprise organizations |
+| `OrganizationUser` | `uniqueId` | Users within a specific organization (child of Organization) |
+| `User` | `id` | All users across enterprise organizations |
+| `Team` | `id` | Teams across organizations |
+| `$.members.edges` (TeamMember) | `$.node.id` | Team members (child entity) |
+| `$.repositories.edges` (TeamRepository) | `$.node.id` | Team repositories (child entity) |
+| `Repository` | `id` | Repositories across organizations |
+| `$.collaborators.edges` (RepositoryCollaborator) | `id` | Repository collaborators (child entity) |
+| `Collaborator` | `id` | Collaborators with expanded traversal |
+| `Label` | `id` | Repository labels |
+| `IssueLabel` | `uniqueId` | Labels on issues (requires `labelId`, `id`) |
+| `PullRequestLabel` | `uniqueId` | Labels on pull requests (requires `labelId`, `id`) |
+| `Issue` | `id` | Repository issues |
+| `IssueAssignee` | `uniqueId` | Issue assignees (requires `issueId`, `id`) |
+| `IssueParticipant` | `uniqueId` | Issue participants (requires `issueId`, `id`) |
+| `PullRequest` | `id` | Repository pull requests |
+| `PullRequestChangedFile` | `uniqueId` | PR changed files (requires `pullRequestId`, `path`) |
+| `PullRequestReview` | `id` | PR reviews |
+| `PullRequestCommit` | `id` | PR commits |
+| `PullRequestAssignee` | `uniqueId` | PR assignees (requires `pullRequestId`, `id`) |
+| `PullRequestParticipant` | `uniqueId` | PR participants (requires `pullRequestId`, `id`) |
+
+### REST Entities
+
+| Entity External ID | Endpoint Pattern | Description |
+|---|---|---|
+| `SecretScanningAlert` | `/enterprises/{slug}/secret-scanning/alerts` or `/orgs/{orgName}/secret-scanning/alerts` | Secret scanning alerts |
+
+## Notes
+
+- Child entities with `$.*` external IDs are nested within their parent's GraphQL response.
+- Entities with `uniqueId` as their unique attribute synthesize a composite ID from multiple fields.
+- The adapter supports both Enterprise Cloud and Enterprise Server deployments.
+
+## Adding New Entity External IDs
+
+**Requires code changes.** Each entity has a dedicated GraphQL query builder and parsing logic. The adapter validates against `ValidEntityExternalIDs`.
+
+### Adding a GraphQL entity:
+
+1. Add a constant in `datasource.go` (e.g., `Project = "Project"`).
+2. Add an entry to `ValidEntityExternalIDs` with the unique ID attribute, parse path, and any required attributes.
+3. Create a new `QueryBuilder` struct in `query.go` with the GraphQL query for the new entity.
+4. Add a case in `ConstructQueryBuilder` to dispatch to the new builder.
+5. If it's a child entity (nested in a parent's response), set the appropriate `ParsePath` and parent reference.
+6. Add tests.
+
+### Adding a REST entity:
+
+1. Add a constant in `datasource.go`.
+2. Add the entity to `ValidEntityExternalIDs`.
+3. Add endpoint mappings in `request.go` for both Enterprise Cloud and Enterprise Server deployment types.
+4. Implement response parsing if the REST response format differs from existing entities.
+5. Add tests.

--- a/pkg/google-workspace/README.md
+++ b/pkg/google-workspace/README.md
@@ -1,0 +1,46 @@
+# Google Workspace Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a Google Admin Directory API path. The adapter constructs URLs as:
+
+```
+{baseURL}/admin/directory/{apiVersion}/{path}?maxResults={pageSize}&domain={domain}
+```
+
+| Entity External ID | API Path | Unique ID Attribute | Max Page Size | Description |
+|---|---|---|---|---|
+| `User` | `/admin/directory/v1/users` | `id` | 500 | Google Workspace users |
+| `Group` | `/admin/directory/v1/groups` | `id` | 1000 | Google Workspace groups |
+| `Member` | `/admin/directory/v1/groups/{groupID}/members` | `uniqueId` | 1000 | Group members (child of Group) |
+
+## Parent-Child Relationships
+
+- `Member` is a child entity - the adapter iterates through groups and fetches members per group.
+- Member's `uniqueId` is synthesized as `"{groupId}-{memberId}"`.
+
+## Response Parsing
+
+Each entity's response is parsed from a different JSON field:
+- `User` → `response.Users`
+- `Group` → `response.Groups`
+- `Member` → `response.Members`
+
+## Notes
+
+- Supports `domain` or `customer` scoping via query parameters.
+- User and Group support ordering by `EMAIL`.
+- Member requires `id` and `groupId` attributes in the request.
+
+## Adding New Entity External IDs
+
+**Requires code changes.** The adapter validates against `ValidEntityExternalIDs` and uses entity-specific URL construction and response parsing.
+
+To add a new entity:
+
+1. Add a constant in `datasource.go` (e.g., `OrgUnit = "OrgUnit"`).
+2. Add an entry to `ValidEntityExternalIDs` with the path template, unique ID attribute, max page size, order-by attribute, and any required attributes.
+3. Add a case in `ConstructEndpoint` in `endpoint.go` for entity-specific query parameters (similar to `AddUserParams`/`AddGroupParams`).
+4. Update `ParseResponse` in `datasource.go` to extract objects from the correct JSON field in the Google API response.
+5. If the entity is a child (like Member), configure the `MemberOf` relationship and collection-based pagination.
+6. Add tests.

--- a/pkg/hashicorp/README.md
+++ b/pkg/hashicorp/README.md
@@ -1,0 +1,49 @@
+# HashiCorp Boundary Adapter
+
+## Entity External IDs
+
+The Entity External ID is used directly as the API path segment. The adapter constructs URLs as:
+
+```
+{baseURL}/v1/{entityExternalID}?page_size={n}&recursive=true&scope_id={scope}
+```
+
+| Entity External ID | Parent Entity | Description |
+|---|---|---|
+| `hosts` | `host-catalogs` | Boundary hosts (fetched per host catalog) |
+| `host-sets` | `host-catalogs` | Boundary host sets (fetched per host catalog) |
+| `credentials` | `credential-stores` | Stored credentials (fetched per credential store) |
+| `credential-libraries` | `credential-stores` | Credential libraries (fetched per credential store) |
+| `accounts` | `auth-methods` | User accounts (fetched per auth method) |
+| `host-catalogs` | (none) | Host catalogs (top-level) |
+| `credential-stores` | (none) | Credential stores (top-level) |
+| `auth-methods` | (none) | Authentication methods (top-level) |
+
+## Parent-Child Relationships
+
+Five entities are children that require iterating through a parent collection first:
+
+| Child | Parent | Query Param Added |
+|---|---|---|
+| `hosts` | `host-catalogs` | `host_catalog_id={parentID}` |
+| `host-sets` | `host-catalogs` | `host_catalog_id={parentID}` |
+| `credentials` | `credential-stores` | `credential_store_id={parentID}` |
+| `credential-libraries` | `credential-stores` | `credential_store_id={parentID}` |
+| `accounts` | `auth-methods` | `auth_method_id={parentID}` |
+
+## Notes
+
+- The adapter is open-ended - any valid Boundary resource type (e.g., `roles`, `users`, `groups`) can be used as an entity external ID.
+- Top-level entities are fetched directly without parent iteration.
+- Pagination uses `list_token` for cursor-based pagination.
+
+## Adding New Entity External IDs
+
+**No code changes required for top-level entities.** The adapter appends any entity external ID directly to the URL path (`/v1/{entityExternalID}`). Simply configure a new entity in SGNL with the Boundary resource type name (e.g., `roles`, `users`, `groups`, `scopes`) and it will work.
+
+To add a new **child** entity (one that requires parent iteration):
+
+1. Add a constant in `datasource.go` for the child entity.
+2. Add a routing case in the `GetPage` function that maps the child to its parent entity and the query parameter to include (following the pattern of `hosts` -> `host-catalogs` with `host_catalog_id`).
+3. Add the entity to `CursorsWithParentEntity` in `validation.go`.
+4. Add tests.

--- a/pkg/identitynow/README.md
+++ b/pkg/identitynow/README.md
@@ -1,0 +1,41 @@
+# SailPoint IdentityNow Adapter
+
+## Entity External IDs
+
+The Entity External ID is used directly as the API path segment. The adapter constructs URLs as:
+
+```
+{baseURL}/{apiVersion}/{entityExternalID}?limit={pageSize}&offset={offset}
+```
+
+The adapter is open-ended - any SailPoint IdentityNow API resource name can be used as an entity external ID.
+
+| Entity External ID | API Path | Description |
+|---|---|---|
+| `accounts` | `/{apiVersion}/accounts` | SailPoint accounts |
+| `entitlements` | `/{apiVersion}/entitlements` | Standalone entitlements |
+| `accountEntitlements` | `/{apiVersion}/accounts/{accountID}/entitlements` | Entitlements scoped to a specific account (special case) |
+
+## Special Cases
+
+`accountEntitlements` is the only entity with custom URL construction. Instead of being appended directly as a path segment, it decomposes into a sub-resource pattern: `/accounts/{accountID}/entitlements`.
+
+All other entity external IDs (e.g., `roles`, `identities`, `access-profiles`) are placed directly into the URL path.
+
+## Supported API Versions
+
+- `v3`
+- `beta`
+
+Each entity can optionally override the default API version via its entity configuration.
+
+## Adding New Entity External IDs
+
+**No code changes required for standard entities.** The adapter appends any entity external ID directly to the URL path. Simply configure a new entity in SGNL with the SailPoint resource name (e.g., `roles`, `identities`, `access-profiles`) and it will work.
+
+To add a new entity with **custom URL construction** (like `accountEntitlements`):
+
+1. Add a constant in `datasource.go`.
+2. Add a case in `ConstructEndpoint` in `endpoint.go` with the custom URL pattern.
+3. If the entity is a sub-resource (like account entitlements), implement collection-based pagination to iterate through the parent resource.
+4. Add tests.

--- a/pkg/jira-datacenter/README.md
+++ b/pkg/jira-datacenter/README.md
@@ -1,0 +1,45 @@
+# Jira Data Center Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a Jira Data Center REST API endpoint. The adapter constructs URLs as:
+
+```
+{baseURL}/rest/api/{apiVersion}/{endpoint}?...
+```
+
+Where `apiVersion` defaults to `latest`.
+
+| Entity External ID | Unique ID Attribute | API Endpoint | Response Array Field | Description |
+|---|---|---|---|---|
+| `User` | `key` | `/rest/api/{version}/group/member?groupname={groupID}` | `values` | Jira users (fetched via group membership, child of Group) |
+| `Issue` | `id` | `/rest/api/{version}/search?jql={filter}` | `issues` | Jira issues |
+| `Group` | `name` | `/rest/api/{version}/groups/picker` | `groups` | Jira groups |
+| `GroupMember` | synthetic `groupID-userKey` | `/rest/api/{version}/group/member?groupname={groupID}` | `values` | Group members (child of Group) |
+
+## Parent-Child Relationships
+
+- `User` is a child of `Group` - users are fetched through group membership.
+- `GroupMember` is a child of `Group` - members are fetched per group.
+
+## Key Differences from Jira Cloud
+
+- Uses configurable API version (`latest` or `2`) instead of fixed `v3`.
+- `User` unique ID is `key` (not `accountId`).
+- `Group` unique ID is `name` (not `groupId`).
+- No Assets (Workspace/Object) support.
+- No `EnhancedIssue` entity.
+- Issue queries dynamically build a `fields` parameter from requested attributes.
+
+## Adding New Entity External IDs
+
+**Requires code changes.** The adapter validates against `ValidEntityExternalIDs` and uses entity-specific endpoint paths and response parsing.
+
+To add a new entity:
+
+1. Add a constant in `datasource.go` (e.g., `ProjectExternalID string = "Project"`).
+2. Add an entry to `ValidEntityExternalIDs` with the unique ID attribute, endpoint path, response array field, and pagination config.
+3. Add URL construction logic in the entity's `ConstructURL` method.
+4. If the response array uses a different JSON field name, specify it in the entity config.
+5. If it's a child entity, configure the parent relationship and collection iteration.
+6. Add tests.

--- a/pkg/jira/README.md
+++ b/pkg/jira/README.md
@@ -1,0 +1,43 @@
+# Jira Cloud Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a Jira Cloud REST API endpoint. The adapter constructs URLs based on three base patterns:
+
+- Default: `{baseURL}/rest/api/3/{endpoint}?...`
+- Workspace: `{baseURL}/rest/servicedeskapi/assets/{endpoint}?...`
+- Object: `{assetBaseURL}/workspace/{workspaceID}/v1/object/aql?...`
+
+| Entity External ID | Unique ID Attribute | API Endpoint | Description |
+|---|---|---|---|
+| `User` | `accountId` | `/rest/api/3/users/search` | Jira users |
+| `Issue` | `id` | `/rest/api/3/search` | Jira issues (JQL search) |
+| `EnhancedIssue` | `id` | `/rest/api/3/search/jql` | Jira issues (new JQL endpoint with token pagination) |
+| `Group` | `groupId` | `/rest/api/3/group/bulk` | Jira groups |
+| `GroupMember` | synthetic `groupId-accountId` | `/rest/api/3/group/member?groupId={id}` | Group members (child of Group) |
+| `Workspace` | `workspaceId` | `/rest/servicedeskapi/assets/workspace` | Jira Assets workspaces |
+| `Object` | `globalId` | `{assetBaseURL}/workspace/{id}/v1/object/aql` | Jira Assets objects (child of Workspace, POST with AQL query) |
+
+## Parent-Child Relationships
+
+- `GroupMember` is a child of `Group` - iterates groups to fetch members per group.
+- `Object` is a child of `Workspace` - iterates workspaces to fetch objects per workspace.
+
+## Notes
+
+- Issue queries use JQL (Jira Query Language) via the `filter` configuration.
+- Object queries use AQL (Asset Query Language) via POST body.
+- `EnhancedIssue` is a newer endpoint using token-based pagination instead of offset.
+
+## Adding New Entity External IDs
+
+**Requires code changes.** The adapter uses a fixed `ValidEntityExternalIDs` map with entity-specific endpoint paths, response parsing, and pagination strategies.
+
+To add a new entity:
+
+1. Add a constant in `datasource.go` (e.g., `Project string = "Project"`).
+2. Add an entry to `ValidEntityExternalIDs` with the unique ID attribute, endpoint path, API base, and pagination type.
+3. Add URL construction logic in `ConstructURL` for the new entity.
+4. If the entity uses a different response structure, update the response parsing logic.
+5. If it's a child entity, configure `MemberOf` to point to the parent and implement collection iteration.
+6. Add tests.

--- a/pkg/ldap/README.md
+++ b/pkg/ldap/README.md
@@ -1,0 +1,77 @@
+# LDAP Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to an LDAP search filter query. Unlike REST-based adapters, external IDs are not used in URL construction - they serve as configuration keys that resolve to LDAP filter strings.
+
+The connection target is a single LDAP server URL (e.g., `ldap://host:389` or `ldaps://host:636`).
+
+| Entity External ID | Default LDAP Filter | Description |
+|---|---|---|
+| `User` | `(&(objectCategory=user)(objectClass=user)(distinguishedName=*))` | Active Directory users |
+| `Group` | `(&(objectCategory=group)(objectClass=group)(distinguishedName=*))` | Active Directory groups |
+| `Computer` | `(&(objectCategory=computer)(name=*))` | Active Directory computers |
+| `GroupMember` | `(&(objectClass=group)({{CollectionAttribute}}={{CollectionId}}))` | Group members (child of Group) |
+
+## How It Works
+
+The Entity External ID is used as a lookup key into the `entityConfig` map to retrieve the LDAP filter query. That filter is then passed to an LDAP search operation against the configured `BaseDN`.
+
+The adapter is open-ended - you can configure any entity external ID with a custom LDAP filter in the `entityConfig`:
+
+```json
+{
+  "entityConfig": {
+    "User": {"query": "(&(objectCategory=user)(objectClass=user)(distinguishedName=*))"},
+    "Group": {"query": "(&(objectCategory=group)(objectClass=group)(distinguishedName=*))"},
+    "Person": {"query": "(&(objectClass=person)(cn=*))"}
+  }
+}
+```
+
+## Parent-Child Relationships
+
+- `GroupMember` is a child of `Group` - the adapter iterates groups and fetches their `member` attribute.
+- Template placeholders `{{CollectionAttribute}}` and `{{CollectionId}}` in the query are replaced at runtime with the parent group's identifying attribute and value.
+
+## Notes
+
+- Default unique ID attributes use `distinguishedName`.
+- Supports Active Directory-specific binary attributes (`objectGUID`, `objectSid`, etc.) with automatic hex conversion.
+- Pagination uses LDAP Simple Paged Results Control.
+- Max page size is 999.
+- Two versions exist (v1.0.0 and v2.0.0) with different GroupMember query strategies.
+
+## Adding New Entity External IDs
+
+**No code changes required.** The adapter is driven entirely by the `entityConfig` map in the adapter configuration. To add a new entity, include it in the config with its LDAP filter query:
+
+```json
+{
+  "entityConfig": {
+    "OrganizationalUnit": {
+      "query": "(&(objectCategory=organizationalUnit)(ou=*))"
+    },
+    "Contact": {
+      "query": "(&(objectClass=contact)(mail=*))"
+    }
+  }
+}
+```
+
+For a new **child** entity (scoped to a parent collection), also include `memberOf`, `collectionAttribute`, `memberAttribute`, and related fields:
+
+```json
+{
+  "entityConfig": {
+    "RoleMember": {
+      "query": "(&(objectClass=group)({{CollectionAttribute}}={{CollectionId}}))",
+      "memberOf": "Role",
+      "collectionAttribute": "distinguishedName",
+      "memberAttribute": "member",
+      "memberUniqueIdAttribute": "distinguishedName",
+      "memberOfUniqueIdAttribute": "distinguishedName"
+    }
+  }
+}
+```

--- a/pkg/my-sql/README.md
+++ b/pkg/my-sql/README.md
@@ -1,0 +1,65 @@
+# MySQL Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a MySQL table name. The adapter constructs SQL queries as:
+
+```sql
+SELECT *, CAST({uniqueAttribute} AS CHAR(50)) AS str_id, COUNT(*) OVER() AS total_remaining_rows
+FROM {entityExternalID}
+WHERE CAST({uniqueAttribute} AS CHAR(50)) > ?
+ORDER BY str_id ASC
+LIMIT ?
+```
+
+The adapter is open-ended - any valid MySQL table name can be used as an entity external ID.
+
+| Entity External ID | SQL Table | Description |
+|---|---|---|
+| `users` | `users` | Users table |
+| `groups` | `groups` | Groups table |
+
+## How It Works
+
+The Entity External ID is used directly as the table name in the SQL `FROM` clause. Attribute external IDs map to column names in the result set.
+
+Example with entity external ID `users`, unique attribute `id`:
+```sql
+SELECT *, CAST(`id` AS CHAR(50)) AS `str_id`, COUNT(*) OVER() AS `total_remaining_rows`
+FROM `users`
+WHERE (CAST(`id` AS CHAR(50)) > ?)
+ORDER BY `str_id` ASC
+LIMIT ?
+```
+
+## Connection
+
+The adapter connects via TCP using the MySQL driver:
+```
+{username}:{password}@tcp({host:port})/{database}
+```
+
+## Validation
+
+Entity external IDs (table names) and unique attribute external IDs are validated against:
+```
+^[a-zA-Z0-9$_]{1,128}$
+```
+
+This prevents SQL injection since table names cannot be parameterized in prepared statements.
+
+## Notes
+
+- Pagination uses cursor-based keyset pagination (comparing cast-to-CHAR values).
+- Filters are configured per entity external ID in the adapter configuration.
+- The adapter uses the `goqu` query builder library for SQL construction.
+- Two versions exist: `0.0.1-alpha` and `0.0.2-alpha`.
+
+## Adding New Entity External IDs
+
+**No code changes required.** The adapter uses any entity external ID directly as the MySQL table name in the `FROM` clause. Simply configure a new entity in SGNL with the MySQL table name (e.g., `employees`, `orders`, `departments`) and it will work.
+
+Requirements for the entity external ID:
+- Must match the regex `^[a-zA-Z0-9$_]{1,128}$` (validated to prevent SQL injection).
+- Must correspond to an existing table in the configured database.
+- Attribute external IDs must match column names in that table.

--- a/pkg/okta/README.md
+++ b/pkg/okta/README.md
@@ -1,0 +1,47 @@
+# Okta Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to an Okta API resource path. The adapter constructs URLs as:
+
+```
+{baseURL}/api/v1/{resource}?limit={pageSize}
+```
+
+| Entity External ID | API Path | Unique ID Attribute | Description |
+|---|---|---|---|
+| `User` | `/api/v1/users` | `id` | Okta users |
+| `Group` | `/api/v1/groups` | `id` | Okta groups |
+| `GroupMember` | `/api/v1/groups/{groupID}/users` | `id` | Group members (child of Group) |
+| `Application` | `/api/v1/apps` | `id` | Okta applications |
+
+## Parent-Child Relationships
+
+- `GroupMember` is a child of `Group` - the adapter iterates through groups and fetches members per group.
+
+## Filter and Search Support
+
+| Entity | Filter | Search | Default Filter |
+|---|---|---|---|
+| `User` | Yes | Yes (mutually exclusive with filter) | None |
+| `Group` | Yes | Yes (mutually exclusive with filter) | `type eq "OKTA_GROUP" or type eq "APP_GROUP"` |
+| `GroupMember` | No | No | None |
+| `Application` | Yes | No | None |
+
+## Notes
+
+- Group has a default filter applied when neither filter nor search is configured.
+- Pagination uses Link header-based cursors (Okta's standard pagination).
+
+## Adding New Entity External IDs
+
+**Requires code changes.** The adapter validates against `ValidEntityExternalIDs` and uses a switch statement in `endpoint.go` to construct entity-specific URL paths.
+
+To add a new entity:
+
+1. Add a constant in `datasource.go` (e.g., `Role string = "Role"`).
+2. Add the entity to `ValidEntityExternalIDs`.
+3. Add a case in the `switch` statement in `ConstructEndpoint` in `endpoint.go` with the Okta API path.
+4. If the entity supports filter or search, add handling in the endpoint construction.
+5. If it's a child entity (like GroupMember), implement collection-based pagination with a parent reference.
+6. Add tests.

--- a/pkg/pagerduty/README.md
+++ b/pkg/pagerduty/README.md
@@ -1,0 +1,46 @@
+# PagerDuty Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a PagerDuty API path segment. The adapter constructs URLs as:
+
+```
+https://api.pagerduty.com/{entityExternalID}?offset={cursor}&limit={pageSize}
+```
+
+| Entity External ID | API Endpoint | Unique ID Attribute | Description |
+|---|---|---|---|
+| `users` | `GET /users` | `id` | PagerDuty users |
+| `teams` | `GET /teams` | `id` | PagerDuty teams |
+| `oncalls` | `GET /oncalls` | composite | On-call schedules |
+| `members` | `GET /teams/{teamID}/members` | composite | Team members (child of teams) |
+
+## Parent-Child Relationships
+
+- `members` is a child of `teams` - the adapter iterates through teams and fetches members per team.
+
+## Composite Unique IDs
+
+- `members`: Synthesized as `{teamID}-{userID}` since a user can belong to multiple teams.
+- `oncalls`: Synthesized as `{escalation_policy.id}-{user.id}-{start}-{end}` since on-call objects lack a native unique ID.
+
+## Notes
+
+- The base URL is always `https://api.pagerduty.com` (enforced by validation).
+- Pagination uses offset-based pagination.
+- Additional query parameters can be configured per entity (e.g., `include[]=contact_methods&include[]=teams` for users).
+- Max page size is 100.
+
+## Adding New Entity External IDs
+
+**Requires code changes for child entities; top-level entities work without changes.** The adapter appends the entity external ID directly as a URL path segment for non-member entities.
+
+For a new **top-level** entity (like `services`, `escalation_policies`):
+- No code changes needed. Configure the entity in SGNL with the PagerDuty resource name and it will be fetched from `https://api.pagerduty.com/{entityExternalID}`.
+
+For a new **child** entity (scoped to a parent, like `members` is scoped to `teams`):
+
+1. Add routing logic in `datasource.go` to construct the parent-scoped URL (e.g., `/teams/{parentID}/members`).
+2. Implement collection-based pagination to iterate through the parent entity.
+3. Implement composite unique ID synthesis (since child objects typically lack a globally unique ID).
+4. Add tests.

--- a/pkg/rootly/README.md
+++ b/pkg/rootly/README.md
@@ -1,0 +1,55 @@
+# Rootly Adapter
+
+## Entity External IDs
+
+The Entity External ID is used directly as the API path segment. The adapter constructs URLs as:
+
+```
+{address}/{apiVersion}/{entityExternalID}?page[size]={pageSize}&page[number]={page}
+```
+
+The adapter is open-ended - any Rootly API resource name can be used as an entity external ID.
+
+| Entity External ID | API Endpoint | Description |
+|---|---|---|
+| `incidents` | `/v1/incidents` | Rootly incidents |
+| `users` | `/v1/users` | Rootly users |
+| `teams` | `/v1/teams` | Rootly teams |
+
+## How It Works
+
+The Entity External ID is appended directly as a path segment after the base URL and API version. Any valid Rootly API resource name will work.
+
+Example URL:
+```
+https://api.rootly.com/v1/incidents?page[size]=100&page[number]=1&filter[status]=started&include=form_field_values
+```
+
+## Configuration
+
+Filters and includes are configured per entity using the entity external ID as the map key:
+
+```json
+{
+  "apiVersion": "v1",
+  "filters": {
+    "incidents": "status=started&severity=high",
+    "users": "email=user@example.com"
+  },
+  "includes": {
+    "incidents": "roles",
+    "users": "role,email_addresses"
+  }
+}
+```
+
+## Notes
+
+- The only supported API version is `v1`.
+- Pagination uses page-number-based pagination (`page[size]` + `page[number]`).
+
+## Adding New Entity External IDs
+
+**No code changes required.** The adapter appends any entity external ID directly as a URL path segment. Simply configure a new entity in SGNL with the Rootly API resource name (e.g., `services`, `environments`, `functionalities`, `severities`) and it will work.
+
+Filters and includes for the new entity can be added via the adapter configuration using the entity external ID as the map key.

--- a/pkg/salesforce/README.md
+++ b/pkg/salesforce/README.md
@@ -1,0 +1,63 @@
+# Salesforce Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a Salesforce object (table) name. The adapter constructs SOQL queries as:
+
+```
+SELECT Id,{attributes} FROM {entityExternalID} [WHERE {filter}] ORDER BY Id ASC
+```
+
+Delivered via the Salesforce REST API:
+```
+{baseURL}/services/data/v{apiVersion}/query?q={SOQL}
+```
+
+The adapter is open-ended - any valid Salesforce object name (standard or custom) can be used as an entity external ID.
+
+| Entity External ID | Salesforce Object | Description |
+|---|---|---|
+| `Account` | Account | Salesforce accounts |
+| `Contact` | Contact | Salesforce contacts |
+| `User` | User | Salesforce users |
+| `Case` | Case | Support cases |
+| `CustomObject__c` | (any custom object) | Custom Salesforce objects |
+
+## How It Works
+
+The Entity External ID is URL-escaped and placed directly into the SOQL `FROM` clause. The adapter builds a `SELECT` statement from the configured attribute external IDs plus the required `Id` field.
+
+Example URL (first page):
+```
+https://instance.salesforce.com/services/data/v58.0/query?q=SELECT+Id,CaseNumber,Status+FROM+Case+WHERE+Status+%3D+%27Open%27+ORDER+BY+Id+ASC
+```
+
+Subsequent pages use the cursor URL returned by Salesforce:
+```
+https://instance.salesforce.com/services/data/v58.0/query/0r8Hu1lKCluUiC9IMK-200
+```
+
+## Required Attribute
+
+Every request must include the attribute with external ID `Id` - this is Salesforce's universal unique identifier.
+
+## Attribute External IDs
+
+Attribute external IDs can be:
+- Plain field names: `Id`, `Name`, `CustomField__c`
+- JSONPath format for relationship traversal: `$.Account.Name` (up to 5 levels)
+
+## Supported API Versions
+
+`52.0` through `58.0`
+
+## Notes
+
+- Page size range: 200-2000.
+- Filters are keyed by entity external ID in the adapter configuration.
+
+## Adding New Entity External IDs
+
+**No code changes required.** The adapter places any entity external ID directly into the SOQL `FROM` clause. Simply configure a new entity in SGNL with the Salesforce object API name (e.g., `Opportunity`, `Lead`, `Task`, or a custom object like `MyObject__c`) and it will work.
+
+To find valid object names, check the Salesforce Object Reference or use the Describe API (`/services/data/v{version}/sobjects/`). Custom objects always end with `__c`.

--- a/pkg/scim/README.md
+++ b/pkg/scim/README.md
@@ -1,0 +1,58 @@
+# SCIM 2.0 Adapter
+
+## Entity External IDs
+
+The Entity External ID is used directly as the API path segment. The adapter constructs URLs as:
+
+```
+{baseURL}/{entityExternalID}?startIndex={cursor}&count={pageSize}
+```
+
+The adapter is open-ended - any SCIM 2.0 resource type name can be used as an entity external ID.
+
+| Entity External ID | API Endpoint | Description |
+|---|---|---|
+| `Users` | `{baseURL}/Users` | SCIM users |
+| `Groups` | `{baseURL}/Groups` | SCIM groups |
+
+## How It Works
+
+The Entity External ID is appended as a path segment to the base URL. This follows the SCIM 2.0 standard where resource types are accessed by name in the URL path.
+
+Example URL:
+```
+https://scim.example.com/Users?startIndex=1&count=100&filter=userType+eq+"Employee"&sortBy=userName&sortOrder=ascending
+```
+
+## Configuration
+
+Query parameters can be configured per entity using the entity external ID as the map key:
+
+```json
+{
+  "queryParams": {
+    "Users": {
+      "filter": "userType eq \"Employee\"",
+      "sortBy": "userName",
+      "ascending": true
+    },
+    "Groups": {
+      "filter": "displayName co \"Engineering\"",
+      "sortBy": "displayName",
+      "ascending": true
+    }
+  }
+}
+```
+
+## Notes
+
+- Pagination uses SCIM's standard `startIndex`/`count` parameters (1-based indexing).
+- Supports optional `filter`, `sortBy`, and `sortOrder` query parameters per entity.
+- Any SCIM-compliant identity provider (Okta SCIM, Azure AD SCIM, etc.) can be used as the base URL.
+
+## Adding New Entity External IDs
+
+**No code changes required.** The adapter appends any entity external ID directly as a URL path segment. Simply configure a new entity in SGNL with the SCIM resource type name (e.g., `Users`, `Groups`, `Roles`, `Entitlements`) and it will work.
+
+Query parameters for the new entity can be added via the adapter configuration using the entity external ID as the `queryParams` map key.

--- a/pkg/servicenow/README.md
+++ b/pkg/servicenow/README.md
@@ -1,0 +1,56 @@
+# ServiceNow Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a ServiceNow table name. The adapter constructs URLs as:
+
+```
+{baseURL}/api/now/{apiVersion}/table/{entityExternalID}?sysparm_fields={fields}&sysparm_limit={pageSize}
+```
+
+| Entity External ID | ServiceNow Table | Description |
+|---|---|---|
+| `sys_user` | sys_user | ServiceNow users |
+| `sys_user_group` | sys_user_group | User groups |
+| `sys_user_grmember` | sys_user_grmember | Group membership records |
+| `sn_customerservice_case` | sn_customerservice_case | Customer service cases |
+| `incident` | incident | Incidents |
+| `change_request` | change_request | Change requests |
+| `change_task` | change_task | Change tasks |
+
+## How It Works
+
+The Entity External ID is placed directly into the URL as the table name. ServiceNow's Table API returns all records from that table wrapped in a `"result"` JSON array.
+
+Example URL:
+```
+https://instance.service-now.com/api/now/v2/table/change_request?sysparm_fields=sys_id,number,state&sysparm_limit=100&sysparm_query=ORDERBYsys_id
+```
+
+## Response Structure
+
+ServiceNow always wraps its response in a top-level `result` key:
+
+```json
+{
+  "result": [
+    {"sys_id": "...", "number": "CHG0000001", ...},
+    ...
+  ]
+}
+```
+
+The adapter parses objects from within `result` - attribute external IDs correspond to the JSON keys inside each object (e.g., `sys_id`, `state`, `assigned_to`).
+
+## Notes
+
+- Supports optional custom URL paths instead of the default `/api/now` prefix.
+- Pagination uses ServiceNow's `Link` header with `rel="next"` for cursor-based pagination.
+- The adapter is open-ended - any valid ServiceNow table name can be used as an entity external ID.
+- All requests include `sysparm_exclude_reference_link=true` and order by `sys_id`.
+
+## Adding New Entity External IDs
+
+**No code changes required.** The adapter places any entity external ID directly into the URL path as the table name. Simply configure a new entity in SGNL with the ServiceNow table name (e.g., `problem`, `kb_knowledge`, `cmdb_ci_server`) and it will work.
+
+The predefined constants in `datasource.go` (`sys_user`, `sys_user_group`, etc.) exist only for internal reference - the adapter does not validate against them. Any string passed as the entity external ID is used as-is in the API URL.

--- a/pkg/workday/README.md
+++ b/pkg/workday/README.md
@@ -1,0 +1,55 @@
+# Workday Adapter
+
+## Entity External IDs
+
+The Entity External ID maps to a WQL (Workday Query Language) table name. The adapter constructs URLs as:
+
+```
+{baseURL}/api/wql/{apiVersion}/{organizationID}/data?limit={pageSize}&offset={offset}&query={WQL}
+```
+
+The WQL query uses the entity external ID in the `FROM` clause:
+
+```sql
+SELECT {columns} FROM {entityExternalID} [ORDER BY {uniqueIdColumn} ASC]
+```
+
+The adapter is open-ended - any valid WQL table name can be used as an entity external ID.
+
+| Entity External ID | WQL Table | Description |
+|---|---|---|
+| `allWorkers` | allWorkers | All worker records |
+
+## Attribute External IDs
+
+Attributes use either plain column names or JSONPath expressions:
+
+| Format | Example | WQL Column |
+|---|---|---|
+| Plain name | `employeeID` | `employeeID` |
+| JSONPath | `$.worker.id` | `worker` (first path segment) |
+| JSONPath | `$.managementLevel.descriptor` | `managementLevel` |
+| JSONPath array | `$.email_Work[0].descriptor` | `email_Work` |
+
+The `AttrExternalIDToColumnName` function converts JSONPath attributes to their top-level column name for the SELECT clause.
+
+## Example
+
+Entity External ID `allWorkers` with various attributes produces:
+
+```
+https://instance.workday.com/api/wql/v1/SGNL/data?limit=100&offset=0&query=SELECT+FTE,+company,+email_Work,+employeeID,+gender,+hireDate,+jobTitle,+managementLevel,+positionID,+worker,+workerActive+FROM+allWorkers
+```
+
+## Notes
+
+- The only supported API version is `v1`.
+- Max page size is 1000.
+- Child entity external IDs (e.g., `email_Work`) are included as columns in the parent's SELECT query.
+- Columns are sorted alphabetically in the SELECT clause.
+
+## Adding New Entity External IDs
+
+**No code changes required.** The adapter places any entity external ID directly into the WQL `FROM` clause. Simply configure a new entity in SGNL with the WQL table name (e.g., `allActiveEmployees`, `allCompanies`, `allLocations`) and it will work.
+
+To find valid WQL table names, refer to Workday's WQL Data Dictionary or use the Workday REST API to list available data sources.


### PR DESCRIPTION
**Description of changes**

# PR: Add Entity External ID Documentation to Adapter Packages

## Summary

Adds a `README.md` to each adapter package in `pkg/` that documents what the Entity External ID means, how it maps to the underlying data source, how it's used in endpoint/query construction, and whether/how new entity external IDs can be added.

## Motivation

The Entity External ID is a critical configuration value when setting up SGNL Systems of Record, but its meaning varies significantly across adapters - it could be a REST API path segment, a database table name, a GraphQL entity type, an LDAP filter key, or an S3 filename. This documentation makes it clear for each adapter what value to use and why, and provides guidance on extensibility.

## Changes

### New Files (22 READMEs)

| Package | External ID Maps To | Extensibility |
|---|---|---|
| `pkg/azuread/README.md` | Microsoft Graph API path (`/users`, `/groups`, etc.) | Code change required |
| `pkg/bamboohr/README.md` | BambooHR Custom Reports API path | Code change required |
| `pkg/crowdstrike/README.md` | GraphQL entity type or REST endpoint path | Code change required |
| `pkg/duo/README.md` | Duo Admin API path segment | Code change required |
| `pkg/github/README.md` | GraphQL query type or REST resource name | Code change required |
| `pkg/google-workspace/README.md` | Google Admin Directory API path | Code change required |
| `pkg/hashicorp/README.md` | HashiCorp Boundary API resource path | No code change (top-level) |
| `pkg/identitynow/README.md` | SailPoint IdentityNow API resource path | No code change (standard) |
| `pkg/jira/README.md` | Jira Cloud REST API endpoint | Code change required |
| `pkg/jira-datacenter/README.md` | Jira Data Center REST API endpoint | Code change required |
| `pkg/okta/README.md` | Okta API resource path segment | Code change required |
| `pkg/servicenow/README.md` | ServiceNow table name | No code change |
| `pkg/pagerduty/README.md` | PagerDuty API path segment | No code change (top-level) |
| `pkg/rootly/README.md` | Rootly API resource path segment | No code change |
| `pkg/salesforce/README.md` | Salesforce object name (SOQL `FROM` clause) | No code change |
| `pkg/scim/README.md` | SCIM 2.0 resource type as URL path | No code change |
| `pkg/workday/README.md` | WQL table name | No code change |
| `pkg/ldap/README.md` | Configuration key for LDAP search filter | No code change (config-driven) |
| `pkg/aws-s3/README.md` | CSV filename in S3 bucket | No code change |
| `pkg/aws/README.md` | AWS IAM SDK API call selector | Code change required |
| `pkg/db2/README.md` | DB2 table name | No code change |
| `pkg/my-sql/README.md` | MySQL table name | No code change |

## What Each README Covers

- **Entity External ID table** - all supported values and what they map to
- **URL/query construction** - how the external ID is used to build the API request
- **Parent-child relationships** - which entities are children that require iterating a parent collection
- **Configuration notes** - relevant config options, pagination details, and constraints
- **Adapter-specific details** - e.g., CrowdStrike's full GraphQL query examples, Salesforce's SOQL construction, database adapters' SQL injection validation
- **Adding New Entity External IDs** - whether code changes are required, and step-by-step instructions for adding new entities

## Extensibility Summary

### No code changes required (open-ended adapters)

These adapters pass the entity external ID directly to the data source. New entities can be added purely through SGNL configuration:

| Adapter | What to configure |
|---|---|
| ServiceNow | Any ServiceNow table name |
| Rootly | Any Rootly API resource name |
| Salesforce | Any Salesforce object API name |
| SCIM | Any SCIM 2.0 resource type |
| Workday | Any WQL table name |
| LDAP | Any name + LDAP filter in `entityConfig` JSON |
| AWS S3 | Any CSV filename in the bucket |
| DB2 | Any DB2 table name |
| MySQL | Any MySQL table name (matching `^[a-zA-Z0-9$_]{1,128}$`) |
| HashiCorp | Any Boundary resource (child entities need code) |
| IdentityNow | Any SailPoint resource (sub-resources need code) |
| PagerDuty | Any top-level resource (child entities need code) |

### Requires code changes (fixed adapters)

These adapters validate against a hardcoded set of entity external IDs and have entity-specific logic (URL construction, query building, response parsing):

| Adapter | Key files to modify |
|---|---|
| Azure AD | `datasource.go`, `endpoint.go` |
| BambooHR | `datasource.go`, `endpoint.go`, `validation.go` |
| CrowdStrike | `datasource.go`, `query.go` (GraphQL) or `endpoint.go` (REST) |
| Duo | `datasource.go` |
| GitHub | `datasource.go`, `query.go` |
| Google Workspace | `datasource.go`, `endpoint.go` |
| Jira / Jira Data Center | `datasource.go` |
| Okta | `datasource.go`, `endpoint.go` |
| AWS IAM | `datasource.go`, `iam.go` |

## Packages Intentionally Skipped

Utility packages that are not adapters and have no entity external IDs:
- `pkg/auth/`
- `pkg/commonutil/`
- `pkg/condexpr/`
- `pkg/config/`
- `pkg/errors/`
- `pkg/extractor/`
- `pkg/logs/`
- `pkg/mock/`
- `pkg/pagination/`
- `pkg/testutil/`
- `pkg/validation/`

## Testing

Documentation-only change. No code modifications.

## Testing

Documentation-only change. No code modifications.

**API References**

<!--- Please provide links to the documentation where a reviewer can verify all API calls being made. -->

None made

**Pull request intention**

<!--- Please provide the intent of the PR and delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Code improvement (improve test coverage or code readability)

**Pull request checklist**

<!--- Please DO NOT DELETE this checklist; only add more if applicable. -->

- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated documentation (if applicable)
- [ ] I have registered the new adapter (if applicable)
- [ ] I have added a smoke test for the new adapter (if applicable)
- [ ] Any secrets are redacted from smoke test fixtures and no PII is present (if applicable)
