### PR TITLE
CONTID-11204: use dynamic ports in ldap-adapter tests to prevent flaky failures

### DIFF
--- a/cmd/ldap-adapter/ldap_v1_test.go
+++ b/cmd/ldap-adapter/ldap_v1_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	api_adapter_v1 "github.com/sgnl-ai/adapter-framework/api/adapter/v1"
+	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc"
@@ -35,13 +36,14 @@ func getFreePort(t *testing.T) int {
 	t.Helper()
 
 	l, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		t.Fatalf("failed to allocate a free port: %v", err)
-	}
+	require.NoError(t, err, "failed to allocate a free port")
 
 	defer l.Close()
 
-	return l.Addr().(*net.TCPAddr).Port
+	addr, ok := l.Addr().(*net.TCPAddr)
+	require.True(t, ok, "unexpected listener address type: %T", l.Addr())
+
+	return addr.Port
 }
 
 func TestMainFunction_NoPanic(t *testing.T) {

--- a/cmd/ldap-adapter/ldap_v1_test.go
+++ b/cmd/ldap-adapter/ldap_v1_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"reflect"
 	"strings"
@@ -26,6 +27,22 @@ const (
 	// Seed test user using ldapadd.
 	ldifPath = "testdata/test.ldif"
 )
+
+// getFreePort asks the OS for an available ephemeral port and returns it.
+// Using a dynamically allocated port avoids flaky "address already in use"
+// failures that occur when a hardcoded port is already taken on the CI runner.
+func getFreePort(t *testing.T) int {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to allocate a free port: %v", err)
+	}
+
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port
+}
 
 func TestMainFunction_NoPanic(t *testing.T) {
 	t.Setenv("LDAP_ADAPTER_CONNECTOR_SERVICE_URL", "localhost:1234")
@@ -199,7 +216,7 @@ func TestGivenOpenLDAPWithUser_WhenGetPageIsCalled_ThenUserIsReturned(t *testing
 	}
 
 	// Set up the adapter port
-	adapterPort := 54321
+	adapterPort := getFreePort(t)
 	tmpDir := t.TempDir()
 	authTokensPath := tmpDir + "/fake-auth-tokens"
 
@@ -412,7 +429,7 @@ func TestGivenOpenLDAPWithMultipleUsers_WhenPagedGetPageIsCalled_ThenAllUsersAre
 	time.Sleep(500 * time.Millisecond)
 
 	// Set up the adapter port
-	adapterPort := 54322
+	adapterPort := getFreePort(t)
 	tmpDir := t.TempDir()
 	authTokensPath := tmpDir + "/fake-auth-tokens"
 
@@ -649,7 +666,7 @@ func TestGivenOpenLDAPWithGroupMembers_WhenGetGroupMemberPageIsCalled_ThenGroupD
 	time.Sleep(500 * time.Millisecond)
 
 	// Set up the adapter port
-	adapterPort := 54323
+	adapterPort := getFreePort(t)
 	tmpDir := t.TempDir()
 	authTokensPath := tmpDir + "/fake-auth-tokens"
 

--- a/cmd/ldap-adapter/ldap_v2_test.go
+++ b/cmd/ldap-adapter/ldap_v2_test.go
@@ -149,7 +149,7 @@ func TestGivenOpenLDAPWithUser_WhenGetPageIsCalled_ThenUserIsReturned_v2(t *test
 	}
 
 	// Set up the adapter port
-	adapterPort := 54324
+	adapterPort := getFreePort(t)
 	tmpDir := t.TempDir()
 	authTokensPath := tmpDir + "/fake-auth-tokens"
 
@@ -362,7 +362,7 @@ func TestGivenOpenLDAPWithMultipleUsers_WhenPagedGetPageIsCalled_ThenAllUsersAre
 	time.Sleep(500 * time.Millisecond)
 
 	// Set up the adapter port
-	adapterPort := 54325
+	adapterPort := getFreePort(t)
 	tmpDir := t.TempDir()
 	authTokensPath := tmpDir + "/fake-auth-tokens"
 
@@ -599,7 +599,7 @@ func TestGivenOpenLDAPWithGroupMembers_WhenGetGroupMemberPageIsCalled_ThenGroupD
 	time.Sleep(500 * time.Millisecond)
 
 	// Set up the adapter port
-	adapterPort := 54326
+	adapterPort := getFreePort(t)
 	tmpDir := t.TempDir()
 	authTokensPath := tmpDir + "/fake-auth-tokens"
 


### PR DESCRIPTION
**Description of changes**

The ldap-adapter integration tests each started the adapter gRPC server on a hardcoded port (54321-54326). Those ports sit inside the Linux ephemeral port range, the same range the OS draws from for outbound source ports on the tests' own grpc.Dial / testcontainers / LDAP client connections. When one of those connections was randomly assigned a port matching an upcoming test's hardcoded listen port, net.Listen failed with "address already in use", main() called log.Fatal, and the whole package failed the build.

Replace the hardcoded ports with a getFreePort(t) helper that binds to localhost:0 and lets the OS assign a free ephemeral port, eliminating the collision window.

Fixes CONTID-11204


<!--- Please provide a description of this PR. -->

**API References**

<!--- Please provide links to the documentation where a reviewer can verify all API calls being made. -->

**Pull request intention**

<!--- Please provide the intent of the PR and delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Code improvement (improve test coverage or code readability)

**Pull request checklist**

<!--- Please DO NOT DELETE this checklist; only add more if applicable. -->

- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated documentation (if applicable)
- [X] I have registered the new adapter (if applicable)
- [X] I have added a smoke test for the new adapter (if applicable)
- [X] Any secrets are redacted from smoke test fixtures and no PII is present (if applicable)
